### PR TITLE
Mobile polish + snappy scroll animations

### DIFF
--- a/docs/superpowers/plans/2026-06-11-mobile-and-animation.md
+++ b/docs/superpowers/plans/2026-06-11-mobile-and-animation.md
@@ -1,0 +1,660 @@
+# Mobile Polish + Animation Pass Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the mobile load-flash, polish mobile layout, speed up and latch scroll animations, and make the two AI featured cards compact-by-default with an expand for full detail.
+
+**Architecture:** Replace JS `isMobile` (window.innerWidth + resize) with Tailwind `md:` responsive classes. Reuse the existing `useInView` hook (add a `once` latch) and Tailwind `transition`/`transform` classes for all reveals. No animation library, no rAF loops, no `prefers-reduced-motion` handling this pass.
+
+**Tech Stack:** Vite 6, React 18, TypeScript, Tailwind v4, react-icons. Verification per task: `yarn build` (runs `tsc -b && vite build`) and `yarn lint`. There is no unit-test runner in this repo, so verification is build + lint clean + a manual viewport check (375px mobile and desktop).
+
+**Branch:** `feature/mobile-and-animation` (already created off `origin/main` @ e3a37c6). Spec: `docs/superpowers/specs/2026-06-11-mobile-and-animation-design.md`.
+
+**Baseline lint:** `yarn lint` currently reports `6 problems (0 errors, 6 warnings)`. All 6 are pre-existing `react-hooks/exhaustive-deps` ref-cleanup warnings. "No new errors" means stay at 0 errors; do not add new warnings beyond these 6.
+
+---
+
+## File Structure
+
+- `src/hooks/useInView.ts` — add an opt-in `once` latch (reveal once, then stop observing).
+- `src/pages/HeroSection.tsx` — drop `isMobile`; responsive via `md:`.
+- `src/components/ScrollArrow.tsx` — drop `isMobile`; responsive via `md:`; compute scroll offset at click time.
+- `src/components/ProjectModal.tsx` — drop `isMobile`; full-screen vs centered via `md:`.
+- `src/pages/AboutSection.tsx` — faster + latched reveal.
+- `src/pages/SkillsSection.tsx` — faster + latched reveal + capped stagger.
+- `src/pages/ContactSection.tsx` — faster + latched reveal + capped stagger.
+- `src/pages/ExperienceSection.tsx` — faster + latched reveal; mobile left-rail timeline; tighter spacing; date separator `to`.
+- `src/pages/ProjectsSection.tsx` — faster + latched section reveal; More work cards stack on mobile + staggered reveal.
+- `src/components/FeaturedProjectCard.tsx` — compact-by-default with a card-level expander; per-card `useInView` reveal; dense diagram legible on mobile.
+
+---
+
+## Task 1: Add a `once` latch to `useInView`
+
+**Files:**
+- Modify: `src/hooks/useInView.ts`
+
+- [ ] **Step 1: Replace the hook body to support a latch**
+
+Current file toggles `isIntersecting` both ways. Replace the whole file with:
+
+```ts
+// src/hooks/useInView.ts
+import { useEffect, useRef, useState, RefObject } from "react";
+
+/**
+ * Observe an element's viewport intersection.
+ * @param threshold IntersectionObserver threshold.
+ * @param once When true (default), latch to visible on first intersection and
+ *   stop observing, so a fast scroll-out never re-hides revealed content.
+ */
+export default function useInView(
+  threshold = 0.1,
+  once = true
+): [RefObject<HTMLDivElement | null>, boolean] {
+  const [isIntersecting, setIntersecting] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry) return;
+        if (entry.isIntersecting) {
+          setIntersecting(true);
+          if (once) observer.unobserve(element);
+        } else if (!once) {
+          setIntersecting(false);
+        }
+      },
+      { threshold, rootMargin: "0px 0px -10% 0px" }
+    );
+
+    observer.observe(element);
+    return () => observer.unobserve(element);
+  }, [threshold, once]);
+
+  return [ref, isIntersecting];
+}
+```
+
+- [ ] **Step 2: Build + lint**
+
+Run: `yarn build && yarn lint`
+Expected: build succeeds; lint `0 errors` (<= 6 warnings).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/hooks/useInView.ts
+git commit -m "feat: add once-latch and earlier trigger to useInView"
+```
+
+---
+
+## Task 2: Hero de-flash (remove isMobile, responsive via md:)
+
+**Files:**
+- Modify: `src/pages/HeroSection.tsx`
+
+- [ ] **Step 1: Remove the `isMobile` state and resize effect**
+
+Delete the `const [isMobile, setIsMobile] = useState(false);` line and the entire `useEffect` that adds the `resize` listener / `checkMobile`. Keep the `isVisible` IntersectionObserver effect and `handleScrollToProjects`.
+
+- [ ] **Step 2: Replace the section height (drop inline style)**
+
+Change the `<section>` opening tag from the inline `style={{ height: isMobile ? ... }}` form to Tailwind classes:
+
+```tsx
+<section
+  ref={sectionRef}
+  className="w-full relative overflow-hidden h-[calc(100dvh-56px)] min-h-[calc(100dvh-56px)] md:h-screen md:min-h-screen"
+>
+```
+
+- [ ] **Step 3: Replace `isMobile` text-size ternaries with responsive classes**
+
+- Heading `h1`: replace `${isMobile ? "text-5xl" : "text-7xl lg:text-8xl"}` with `text-5xl md:text-7xl lg:text-8xl`.
+- Sub paragraph: replace `${isMobile ? "text-base px-4" : "text-lg"}` with `text-base px-4 md:text-lg md:px-0`.
+
+- [ ] **Step 4: Enlarge the recruiter icon-link tap targets**
+
+For each of the three icon `<a>` (GitHub, Email, LinkedIn) in the recruiter shortcuts row, add `p-2 -m-2` to the existing className so the hit area grows without changing layout. Example:
+
+```tsx
+className="text-gray-500 hover:text-purple-600 active:scale-95 transition-colors p-2 -m-2"
+```
+
+- [ ] **Step 5: Build + lint**
+
+Run: `yarn build && yarn lint`
+Expected: build succeeds; `0 errors`. The Hero `react-hooks/exhaustive-deps` warning count should not increase (removing an effect may reduce it).
+
+- [ ] **Step 6: Manual check**
+
+`yarn dev`, load `http://localhost:5173/` at 375px and desktop: hero fills the screen with no layout jump on load; heading scales; buttons/icons reachable.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/pages/HeroSection.tsx
+git commit -m "refactor: hero responsive via tailwind, remove isMobile flash"
+```
+
+---
+
+## Task 3: ScrollArrow de-flash
+
+**Files:**
+- Modify: `src/components/ScrollArrow.tsx`
+
+- [ ] **Step 1: Remove `isMobile` state + resize effect**
+
+Delete `const [isMobile, setIsMobile] = useState(false);` and the `useEffect` with `checkMobile`/resize listener. Remove now-unused `useState`/`useEffect` imports if they are no longer referenced (keep imports that are still used).
+
+- [ ] **Step 2: Compute the scroll offset at click time**
+
+In `handleClick`, replace the `isMobile ? 60 : 80` expression with an inline check (no state, runs only on click so no flash):
+
+```tsx
+const offset = window.innerWidth < 768 ? 60 : 80;
+const targetPosition = absoluteElementTop - offset;
+```
+
+- [ ] **Step 3: Replace `isMobile` classes with responsive classes**
+
+- Wrapper div: replace `${isMobile ? "bottom-6" : "bottom-12"}` with `bottom-6 md:bottom-12`.
+- Button: replace `${isMobile ? "w-12 h-12" : "w-14 h-14 hover:bg-violet-200"}` with `w-12 h-12 md:w-14 md:h-14 hover:bg-violet-200`.
+- Icon: replace `${isMobile ? "w-7 h-7" : "w-8 h-8"}` with `w-7 h-7 md:w-8 md:h-8`.
+
+- [ ] **Step 4: Build + lint**
+
+Run: `yarn build && yarn lint`
+Expected: build succeeds; `0 errors`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/ScrollArrow.tsx
+git commit -m "refactor: scrollarrow responsive via tailwind, remove isMobile"
+```
+
+---
+
+## Task 4: ProjectModal de-flash
+
+**Files:**
+- Modify: `src/components/ProjectModal.tsx`
+
+- [ ] **Step 1: Remove `isMobile` state + its resize logic**
+
+Delete `const [isMobile, setIsMobile] = useState(false);`. In the `useEffect`, remove the `checkMobile`/resize listener lines but KEEP `setMounted(true)`, the `isOpen` body-overflow lock, and its cleanup. Keep `mounted` state.
+
+- [ ] **Step 2: Make the container + modal box responsive**
+
+- Outer flex container: replace `${isMobile ? "p-0" : "p-4"}` with `p-0 md:p-4`.
+- Modal box: replace the `isMobile ? "w-full h-full rounded-none" : "max-w-2xl w-full max-h-[80vh] rounded-xl"` ternary with:
+  `w-full h-full rounded-none md:w-full md:max-w-2xl md:h-auto md:max-h-[80vh] md:rounded-xl`.
+
+- [ ] **Step 3: Make image, close button, and paddings responsive**
+
+- Header image: replace `${isMobile ? "h-52" : "h-48"}` with `h-52 md:h-48`.
+- Mobile gradient overlay div: replace the `{isMobile && (...)}` guard by always rendering it with `md:hidden` on its className.
+- Close button: replace `${isMobile ? "w-11 h-11" : "w-8 h-8 hover:bg-gray-100"}` with `w-11 h-11 md:w-8 md:h-8 hover:bg-gray-100`.
+- Close icon: replace `<FaTimes size={isMobile ? 20 : 16} />` with `<FaTimes className="w-5 h-5 md:w-4 md:h-4" />` (drop the `size` prop so Tailwind controls size).
+- Content wrapper: replace `${isMobile ? "p-5 pb-8" : "p-5"}` with `p-5 pb-8 md:pb-5`.
+
+- [ ] **Step 4: Make the title/summary/description/heading text responsive**
+
+Replace each remaining `isMobile ? A : B` text-size ternary with the mobile value plus a `md:` override. Specifically:
+- Title `h2`: `text-2xl md:text-xl`.
+- Summary `p`: `text-base md:text-lg`.
+- Description `p`: `text-base leading-relaxed md:text-sm`.
+- "Technologies"/"Key Features" `h3`: `text-lg md:text-md`.
+- Tech pills: `px-3 py-1.5 text-sm md:px-2 md:py-1 md:text-xs`.
+- Tech container gap: `gap-2 md:gap-1.5`.
+- Features `ul`: `text-base md:text-sm`.
+- Action button row: `mt-6 md:mt-3`.
+- Live/repo link buttons: `w-12 h-12 md:w-10 md:h-10` and drop the icon `size` prop in favor of `className="w-5 h-5 md:w-[18px] md:h-[18px]"`.
+
+- [ ] **Step 5: Build + lint**
+
+Run: `yarn build && yarn lint`
+Expected: build succeeds; `0 errors`.
+
+- [ ] **Step 6: Manual check**
+
+Open a More work card on mobile width (full-screen modal, no flash) and desktop (centered modal). Close button and links tappable.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/ProjectModal.tsx
+git commit -m "refactor: projectmodal responsive via tailwind, remove isMobile"
+```
+
+---
+
+## Task 5: AboutSection — faster + latched reveal
+
+**Files:**
+- Modify: `src/pages/AboutSection.tsx`
+
+- [ ] **Step 1: Latch the observer and stop re-hiding**
+
+In the IntersectionObserver effect, change the callback so it only reveals and then unobserves:
+
+```tsx
+const observer = new IntersectionObserver(
+  ([entry]) => {
+    if (entry.isIntersecting) {
+      setIsVisible(true);
+      observer.disconnect();
+    }
+  },
+  { threshold: 0.1, rootMargin: "0px 0px -10% 0px" }
+);
+```
+
+- [ ] **Step 2: Shorten durations**
+
+- Section wrapper: change `duration-1000` to `duration-500`.
+- Heading: change `duration-700 delay-200` to `duration-500 delay-100`.
+- Content block: change `duration-700 delay-500` to `duration-500 delay-200`.
+
+- [ ] **Step 3: Build + lint**
+
+Run: `yarn build && yarn lint`
+Expected: build succeeds; `0 errors`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/pages/AboutSection.tsx
+git commit -m "perf: faster latched reveal for About"
+```
+
+---
+
+## Task 6: SkillsSection — faster + latched + capped stagger
+
+**Files:**
+- Modify: `src/pages/SkillsSection.tsx`
+
+- [ ] **Step 1: Latch the observer**
+
+Change the observer callback as in Task 5 Step 1 (reveal once, `observer.disconnect()`), keeping `rootMargin: "0px 0px -10% 0px"`.
+
+- [ ] **Step 2: Shorten durations**
+
+- Section wrapper: `duration-1000` to `duration-500`.
+- Heading: `duration-700 delay-200` to `duration-500 delay-100`.
+- Intro paragraph: `duration-700 delay-400` to `duration-500 delay-150`.
+- Category block: `duration-700` to `duration-500`.
+
+- [ ] **Step 3: Cap the category and card stagger**
+
+- Category block delay: replace `transitionDelay: isVisible ? \`${600 + catIndex * 200}ms\` : "0ms"` with `transitionDelay: isVisible ? \`${Math.min(catIndex * 80, 240)}ms\` : "0ms"`.
+- Skill card: keep `duration-500` (Tailwind has no `duration-400`), and replace `transitionDelay: isVisible ? \`${800 + catIndex * 200 + skillIndex * 80}ms\` : "0ms"` with a capped value based on position within the category:
+
+```tsx
+style={{
+  transitionDelay: isVisible
+    ? `${Math.min(catIndex * 80 + skillIndex * 40, 300)}ms`
+    : "0ms",
+}}
+```
+
+- [ ] **Step 4: Build + lint**
+
+Run: `yarn build && yarn lint`
+Expected: build succeeds; `0 errors`.
+
+- [ ] **Step 5: Manual check**
+
+Fast-scroll to Skills: all cards are visible quickly (total reveal under ~0.7s) and stay visible when scrolled past.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/pages/SkillsSection.tsx
+git commit -m "perf: faster latched reveal and capped stagger for Skills"
+```
+
+---
+
+## Task 7: ContactSection — faster + latched + capped stagger
+
+**Files:**
+- Modify: `src/pages/ContactSection.tsx`
+
+- [ ] **Step 1: Latch the observer**
+
+Change the observer callback as in Task 5 Step 1 (reveal once, `observer.disconnect()`), `rootMargin: "0px 0px -10% 0px"`.
+
+- [ ] **Step 2: Shorten durations**
+
+- Section wrapper: `duration-1000` to `duration-500`.
+- Heading: `duration-700 delay-200` to `duration-500 delay-100`.
+- Intro paragraph: `duration-700 delay-400` to `duration-500 delay-150`.
+- Icon row container: `duration-700 delay-[600ms]` to `duration-500 delay-200`.
+
+- [ ] **Step 3: Add a per-icon staggered pop-in**
+
+The three contacts currently reveal together. Give each a small staggered scale pop. In the `contacts.map(...)`, add to the `<a>` an index and per-item transition. Replace the `.map(({ icon: Icon, label, href, external }) => (` signature with `.map(({ icon: Icon, label, href, external }, i) => (` and add to the `<a>` className a transform + transition and an inline delay:
+
+```tsx
+className={`group flex flex-col items-center gap-3 transition-all duration-500 ${
+  isVisible ? "opacity-100 scale-100" : "opacity-0 scale-95"
+}`}
+style={{ transitionDelay: isVisible ? `${200 + i * 70}ms` : "0ms" }}
+```
+
+(`duration-500`, not `duration-400` — Tailwind's default scale has no 400.)
+
+(Keep the existing `target`/`rel`/`key` attributes.)
+
+- [ ] **Step 4: Build + lint**
+
+Run: `yarn build && yarn lint`
+Expected: build succeeds; `0 errors`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pages/ContactSection.tsx
+git commit -m "perf: faster latched reveal and icon pop-in for Contact"
+```
+
+---
+
+## Task 8: ExperienceSection — timing + mobile rail + spacing + date separator
+
+**Files:**
+- Modify: `src/pages/ExperienceSection.tsx`
+
+- [ ] **Step 1: Latch the section observer**
+
+In the section-level observer effect, change `([entry]) => setIsVisible(entry.isIntersecting)` to reveal once:
+
+```tsx
+([entry]) => {
+  if (entry.isIntersecting) {
+    setIsVisible(true);
+  }
+},
+```
+
+(The per-item observers below also need latching — Step 2.)
+
+- [ ] **Step 2: Latch the per-item reveal**
+
+In the per-item `IntersectionObserver` effect, change the callback so an item, once revealed, stays revealed:
+
+```tsx
+const obs = new IntersectionObserver(
+  ([entry]) => {
+    if (!entry.isIntersecting) return;
+    setRevealed((state) => {
+      const next =
+        state.length === items.length ? [...state] : Array(items.length).fill(false);
+      next[idx] = true;
+      return next;
+    });
+    obs.unobserve(el);
+  },
+  { threshold: 0.2, rootMargin: "0px 0px -10% 0px" }
+);
+```
+
+- [ ] **Step 3: Shorten durations**
+
+- Section wrapper: `duration-1000` to `duration-500`.
+- Heading: `duration-700 delay-200` to `duration-500 delay-100`.
+- Per-item card wrapper: `duration-700` to `duration-500`.
+
+- [ ] **Step 4: Tighten mobile spacing**
+
+Change the timeline container spacing from `space-y-16` to `space-y-8 md:space-y-16`.
+
+- [ ] **Step 5: Add a mobile left rail + dots**
+
+The center line is currently `hidden md:block`. Add a mobile-only left rail and indent the cards on mobile. Replace the decorative center-line div with two rails:
+
+```tsx
+{/* Mobile left rail */}
+<div className="absolute left-[7px] top-2 bottom-2 w-px bg-gradient-to-b from-purple-300 via-pink-300 to-transparent md:hidden" />
+{/* Desktop center line */}
+<div className="absolute left-1/2 -translate-x-1/2 top-0 bottom-0 w-px bg-gradient-to-b from-purple-300 via-pink-300 to-transparent hidden md:block" />
+```
+
+On the per-item row wrapper, add mobile left padding so cards sit right of the rail: add `pl-6 md:pl-0` to the existing row `className` (the `flex flex-col md:flex-row ...` div).
+
+Add a mobile dot at the start of each item. Inside the per-item row wrapper, as the first child (before the `{!isLeft && ...}` spacer), add:
+
+```tsx
+<span className="absolute left-0 top-2 w-3.5 h-3.5 rounded-full bg-white border-2 border-purple-400 md:hidden" />
+```
+
+For this to anchor correctly, ensure the per-item row wrapper has `relative` in its className (add `relative` to the `flex flex-col md:flex-row items-center gap-8 ...` div).
+
+- [ ] **Step 6: Replace the date em dash separator**
+
+Change the date pill from `{item.start} — {item.end}` to `{item.start} to {item.end}`.
+
+- [ ] **Step 7: Build + lint**
+
+Run: `yarn build && yarn lint`
+Expected: build succeeds; `0 errors`.
+
+- [ ] **Step 8: Manual check**
+
+Mobile: a left rail with dots, cards indented to the right, tighter spacing, dates read "2026-02 to Present". Desktop: unchanged alternating timeline. Fast-scroll: items reveal fast and stay.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/pages/ExperienceSection.tsx
+git commit -m "feat: mobile timeline rail + faster latched reveal for Experience"
+```
+
+---
+
+## Task 9: ProjectsSection — section reveal + More work mobile stack + stagger
+
+**Files:**
+- Modify: `src/pages/ProjectsSection.tsx`
+
+- [ ] **Step 1: Latch the section observer + shorten duration**
+
+Change the observer callback to reveal once:
+
+```tsx
+const observer = new IntersectionObserver(
+  ([entry]) => {
+    if (entry.isIntersecting) setIsVisible(true);
+  },
+  { threshold: 0.05, rootMargin: "0px 0px -10% 0px" }
+);
+```
+
+Change the section wrapper `duration-1000` to `duration-500`.
+
+- [ ] **Step 2: Make More work cards stack on mobile**
+
+On the More work card `<button>`, change `... transition-all duration-300 flex` to `... transition-all duration-300 flex flex-col sm:flex-row`.
+
+Image wrapper: change `relative overflow-hidden w-1/3 min-h-full` to `relative overflow-hidden w-full h-40 sm:w-1/3 sm:h-auto sm:min-h-full`.
+
+Content wrapper: change `p-4 flex flex-col justify-center w-2/3` to `p-4 flex flex-col justify-center w-full sm:w-2/3`.
+
+- [ ] **Step 3: Add a staggered reveal to More work cards (fade + slide + scale)**
+
+The card `<button>` already has `transition-all duration-300` (used for hover). Reuse it — do NOT add a second `transition-all`/`duration`. Just append the reveal state classes to the className (gated by `isVisible`):
+
+```tsx
+` ${isVisible ? "opacity-100 translate-y-0 scale-100" : "opacity-0 translate-y-4 scale-[0.97]"}`
+```
+
+and add an inline style on the same `<button>`:
+
+```tsx
+style={{ transitionDelay: isVisible ? `${Math.min(index * 70, 280)}ms` : "0ms" }}
+```
+
+(Keep the existing `key`, `type`, `onClick`. Note `index` is the `projects.map((project, index) => ...)` index already in scope.)
+
+- [ ] **Step 4: Build + lint**
+
+Run: `yarn build && yarn lint`
+Expected: build succeeds; `0 errors`.
+
+- [ ] **Step 5: Manual check**
+
+Mobile: More work cards are image-on-top, full width, readable. Desktop: two-column row cards. Scrolling in: cards rise + fade + settle with a quick stagger and stay visible.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/pages/ProjectsSection.tsx
+git commit -m "feat: More work mobile stack + lively staggered reveal"
+```
+
+---
+
+## Task 10: FeaturedProjectCard — compact default + expander, per-card reveal, mobile diagram
+
+**Files:**
+- Modify: `src/components/FeaturedProjectCard.tsx`
+
+- [ ] **Step 1: Import the reveal hook**
+
+At the top, add: `import useInView from "../hooks/useInView";` (keep existing imports of `FaPlay`, `FaChevronDown`, and the `FeaturedProject` type).
+
+- [ ] **Step 2: Wire a per-card reveal**
+
+Inside `FeaturedProjectCard`, before the return, add:
+
+```tsx
+const [ref, inView] = useInView(0.12);
+```
+
+On the root `<article>`, add the ref and reveal classes (restrained fade-up, no scale):
+
+```tsx
+<article
+  ref={ref}
+  className={`relative bg-white rounded-2xl border border-gray-200 shadow-sm overflow-hidden transition-all duration-500 ${
+    inView ? "opacity-100 translate-y-0" : "opacity-0 translate-y-6"
+  }`}
+>
+```
+
+- [ ] **Step 3: Wrap the deep content in a card-level expander**
+
+Currently the card renders, in order: header, demo video, "What it does", Architecture (with nested detail), Key design decisions, Stack. Keep header + demo video + "What it does" always visible. Wrap the **Architecture section, the Key design decisions section, and the Stack section** in a single `<details>` placed after the "What it does" `<section>`:
+
+```tsx
+<details className="group">
+  <summary className="flex items-center justify-between gap-4 cursor-pointer list-none rounded-xl border border-gray-200 px-4 py-3 hover:bg-gray-50 transition-colors">
+    <span className="font-semibold text-violet-600 text-sm uppercase tracking-wider">
+      Show full breakdown
+    </span>
+    <FaChevronDown
+      className="w-3.5 h-3.5 text-gray-400 flex-shrink-0 transition-transform duration-200 group-open:rotate-180"
+      aria-hidden="true"
+    />
+  </summary>
+
+  <div className="mt-6">
+    {/* MOVE HERE: the existing Architecture <section>, the Key design
+        decisions <section>, and the Stack <section>, unchanged except for
+        Step 4's diagram tweak. */}
+  </div>
+</details>
+```
+
+Move the three existing `<section>` blocks (Architecture, Key design decisions, Stack) inside that `<div className="mt-6">`. Remove the `mb-8` from whichever moved section is now last (Stack has no `mb`, so leave as is) to avoid a trailing gap; the "What it does" section keeps its `mb-8` to separate it from the summary.
+
+- [ ] **Step 4: Make the dense detail diagram legible on mobile**
+
+In the nested `detailDiagram` block, change the inner image container and image so it can pan horizontally on small screens instead of squishing. Replace:
+
+```tsx
+<div className="px-4 pb-4 overflow-x-auto">
+  <img
+    src={project.detailDiagram.src}
+    alt={project.detailDiagram.alt}
+    className="w-full h-auto mx-auto"
+    loading="lazy"
+  />
+</div>
+```
+
+with:
+
+```tsx
+<div className="px-4 pb-4 overflow-x-auto">
+  <img
+    src={project.detailDiagram.src}
+    alt={project.detailDiagram.alt}
+    className="h-auto mx-auto min-w-[760px] sm:min-w-0 sm:w-full"
+    loading="lazy"
+  />
+</div>
+```
+
+- [ ] **Step 5: Build + lint**
+
+Run: `yarn build && yarn lint`
+Expected: build succeeds; `0 errors`. (The `index` prop on `FeaturedProjectCard` is still used by the header "Featured · NN" label; do not remove it.)
+
+- [ ] **Step 6: Manual check**
+
+Featured cards are short by default (header + video + what it does + a "Show full breakdown" bar). Expanding reveals architecture, design decisions, and stack. The dense Jobs Desktop diagram (inside the nested "Full architecture (detail)") is pannable and legible on a phone. Cards fade up as they scroll in and stay visible.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/FeaturedProjectCard.tsx
+git commit -m "feat: compact featured cards with full-breakdown expander + reveal"
+```
+
+---
+
+## Task 11: Final verification pass
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Clean build + lint**
+
+Run: `yarn build && yarn lint`
+Expected: build succeeds; lint `0 errors` and no more than the 6 pre-existing warnings.
+
+- [ ] **Step 2: Manual sweep at 375px and desktop**
+
+`yarn dev`. Verify, top to bottom:
+- Hero: no load flash, fills viewport, icons/buttons reachable.
+- About/Skills/Contact: reveals are fast (<~0.7s total) and stay visible on fast scroll.
+- Experience: mobile left rail + dots; dates read "... to ..."; desktop alternating layout intact.
+- Work: featured cards compact by default, expand works, dense diagram pannable on mobile; More work cards stack on mobile with a lively staggered reveal.
+- No horizontal scroll at 320–414px.
+
+- [ ] **Step 3: Push the branch**
+
+```bash
+git push -u origin feature/mobile-and-animation
+```
+
+(Do not add any Claude Code attribution to commits or the eventual PR.)
+
+---
+
+## Notes for the implementer
+
+- No `prefers-reduced-motion` handling this pass (explicit user decision).
+- No new dependencies. CSS `transform`/`transition` only.
+- Do not rewrite or force-push `main` history.
+- Tailwind `md` is `>=768px`; the old JS used `<=768` for mobile. The 1px boundary difference at exactly 768 is intentional and acceptable.

--- a/docs/superpowers/specs/2026-06-11-mobile-and-animation-design.md
+++ b/docs/superpowers/specs/2026-06-11-mobile-and-animation-design.md
@@ -11,6 +11,9 @@ Two workstreams on the existing portfolio (Vite + React 18 + Tailwind v4):
    layout flash caused by JS `isMobile` detection.
 2. **Animation**: fill the gaps left after PR #8 and add tasteful liveliness,
    with the **More work** grid as the focus (it is the most static part now).
+3. **Animation timing**: animations are currently too slow on fast scroll, so
+   content stays invisible as the user scrolls past. Make reveals faster, cap
+   the stagger, trigger slightly earlier, and latch them so they never re-hide.
 
 Hard constraints (from the original brief, still in force):
 - Fast and clean: CSS `transform`/`transition` only. No animation libraries,
@@ -34,6 +37,13 @@ Hard constraints (from the original brief, still in force):
     they appear with the section.
   - `ProjectsSection` "More work" grid: no per-card stagger (the pre-PR version
     had it; the rewrite dropped it). This is the part that reads as too plain.
+- Timing problems (cause of the fast-scroll complaint):
+  - Durations are long: sections use `duration-1000`, items `duration-700`.
+  - Stagger delays are large and cumulative, e.g. `SkillsSection` cards use
+    `800 + catIndex*200 + skillIndex*80` ms, so the last card can start ~2s in.
+  - Reveals are two-way: the observers call `setIsVisible(entry.isIntersecting)`
+    (and `useInView` returns raw `isIntersecting`), so scrolling a section out of
+    view re-hides it. On a fast scroll the content can be mid-fade or hidden.
 - `isMobile` via `window.innerWidth` + resize listener (state starts `false`,
   so a wrong-layout frame flashes on load) lives in:
   - `HeroSection.tsx` — drives section height and heading text size.
@@ -113,10 +123,61 @@ Mechanism: reuse `useInView` + Tailwind transition classes. No new deps.
 - Durations/easing consistent with the site (`duration-500`–`700`, ease-out,
   `translate-y` 6–10px).
 
+## D. Animation timing (fast-scroll fix)
+
+Applies to the existing animated sections as well as the new ones, since the
+complaint is general.
+
+- **Shorter durations**: section fades `duration-1000 → duration-500`; item
+  reveals `duration-700 → duration-400`.
+- **Capped stagger**: replace large cumulative delays with a small step that is
+  capped so the last item is not far behind the first. Target: step ~50–70ms,
+  total reveal window <= ~300ms. Concretely, `SkillsSection`'s
+  `800 + catIndex*200 + skillIndex*80` becomes a capped formula such as
+  `Math.min(index * 50, 300)` over the flattened card index, and the big base
+  offsets (600/800ms) are dropped. The More work grid uses the same capped step.
+- **Latch (never re-hide)**: once an element has revealed, keep it revealed.
+  - `useInView`: add a `once` behavior — after the first intersection, set true,
+    stop observing, and never set back to false.
+  - Inline-observer sections (`AboutSection`, `SkillsSection`, `ContactSection`,
+    `ExperienceSection`, `ProjectsSection`): change
+    `setIsVisible(entry.isIntersecting)` so it only sets true and then unobserves,
+    instead of toggling with intersection.
+- **Trigger slightly earlier**: keep/observe a bottom `rootMargin` (e.g.
+  `0px 0px -10% 0px`) so the reveal starts as the element approaches the
+  viewport, so content is already visible by the time a fast scroll stops.
+
+Net effect: animations still play, but finish quickly and stay put, so fast
+scrolling never leaves content stuck faded out.
+
+## E. Featured cards: compact by default, expand for full detail
+
+The two `FeaturedProjectCard`s are too tall. Show only the essentials by
+default and put the deep content behind a single card-level expander.
+
+- **Always visible (default):** header (title, Prototype badge, tagline, honest
+  status line), the demo video, and the "What it does" paragraph. This is the
+  recruiter hook and stays short.
+- **Behind a card-level expander** ("Show full breakdown", same `<details>` +
+  rotating chevron pattern used elsewhere, closed by default): the Architecture
+  section (glance diagram + the existing collapsible dense detail), the Key
+  design decisions list, and the Stack.
+- Nesting: the per-decision `<details>` and the dense-diagram `<details>` remain
+  inside the expanded region. Nested `<details>` is fine.
+- The entrance reveal (section C) applies to the compact card; expanding is a
+  separate user action.
+
 ## Components touched
 
-`HeroSection.tsx`, `ScrollArrow.tsx`, `ProjectModal.tsx`, `ProjectsSection.tsx`,
-`FeaturedProjectCard.tsx`, `ExperienceSection.tsx`. Reuse `hooks/useInView.ts`.
+- De-flash refactor: `HeroSection.tsx`, `ScrollArrow.tsx`, `ProjectModal.tsx`.
+- Mobile layout: `ProjectsSection.tsx`, `ExperienceSection.tsx`,
+  `FeaturedProjectCard.tsx`.
+- Animation reveal + timing: `FeaturedProjectCard.tsx`, `ProjectsSection.tsx`,
+  and the timing/latch pass across `AboutSection.tsx`, `SkillsSection.tsx`,
+  `ContactSection.tsx`, `ExperienceSection.tsx`, plus `hooks/useInView.ts`
+  (add `once` latch).
+- Compact featured card: `FeaturedProjectCard.tsx`.
+
 No data or copy changes except the Experience date separator. No new
 dependencies.
 

--- a/docs/superpowers/specs/2026-06-11-mobile-and-animation-design.md
+++ b/docs/superpowers/specs/2026-06-11-mobile-and-animation-design.md
@@ -1,0 +1,134 @@
+# Mobile polish + animation pass — design
+
+Date: 2026-06-11
+Branch: `feature/mobile-and-animation` (based on `origin/main` @ e3a37c6, which has the merged PR #8 work)
+
+## Goal
+
+Two workstreams on the existing portfolio (Vite + React 18 + Tailwind v4):
+
+1. **Mobile**: polish layout/readability rough spots and remove the load-time
+   layout flash caused by JS `isMobile` detection.
+2. **Animation**: fill the gaps left after PR #8 and add tasteful liveliness,
+   with the **More work** grid as the focus (it is the most static part now).
+
+Hard constraints (from the original brief, still in force):
+- Fast and clean: CSS `transform`/`transition` only. No animation libraries,
+  no JS animation loops (rAF), nothing that hurts load.
+- `prefers-reduced-motion` is intentionally **not** handled this pass (user
+  decision). Noted as a possible later follow-up.
+- No em dashes in any new copy. Keep accessibility (alt text, keyboard nav,
+  tap targets) intact.
+- Enhance within the existing design system (white bg, violet/`purple-600 →
+  pink-500 → blue-500` gradient, rounded cards, IntersectionObserver fades).
+
+## Current state (verified in merged code)
+
+- Animations: every section already has a section-level fade-in-up via an
+  `IntersectionObserver` + `opacity`/`translate-y` Tailwind transition.
+  `ExperienceSection` reveals items individually; `SkillsSection` staggers
+  cards. A reusable hook exists: `src/hooks/useInView.ts` (returns `[ref,
+  isIntersecting]`).
+- Gaps from PR #8:
+  - `FeaturedProjectCard` (AI Task Pipeline, Jobs Desktop): no per-card entrance;
+    they appear with the section.
+  - `ProjectsSection` "More work" grid: no per-card stagger (the pre-PR version
+    had it; the rewrite dropped it). This is the part that reads as too plain.
+- `isMobile` via `window.innerWidth` + resize listener (state starts `false`,
+  so a wrong-layout frame flashes on load) lives in:
+  - `HeroSection.tsx` — drives section height and heading text size.
+  - `ScrollArrow.tsx` — drives bottom offset, button/icon size, and the
+    click-time scroll offset (60 vs 80).
+  - `ProjectModal.tsx` — drives full-screen vs centered modal and many sizes.
+- Mobile rough spots:
+  - "More work" cards use a fixed `flex` `w-1/3` image + `w-2/3` text at all
+    widths, cramped on narrow phones.
+  - `ExperienceSection` on mobile is a vertical stack of floating cards (the
+    center rail is `hidden md:block`); large `space-y-16`; date pill uses an
+    em dash separator.
+  - The dense `jobapp-architecture.svg` (1480 wide) inside the collapsible
+    `<details>` squishes to unreadable on phones.
+  - Hero icon links have a small tap target (icon-sized, no padding).
+
+## A. Mobile de-flash refactor
+
+Approach: replace `isMobile` state + resize listeners with Tailwind `md:`
+responsive classes. Breakpoint maps `<=768` (JS mobile) to Tailwind `md`
+(`>=768` desktop); the one-pixel difference at exactly 768 is negligible.
+
+- **HeroSection.tsx**: remove `isMobile` state + resize effect.
+  - Height: `h-[calc(100dvh-56px)] md:h-screen` (and matching `min-h-*`), via
+    Tailwind arbitrary values, replacing the inline `style` height.
+  - Heading: `text-5xl md:text-7xl lg:text-8xl`. Sub copy: `text-base md:text-lg`.
+  - Keep the existing CSS gradient-mesh background and the fade-in transitions.
+- **ScrollArrow.tsx**: remove `isMobile` state + resize effect.
+  - `bottom-6 md:bottom-12`, button `w-12 h-12 md:w-14 md:h-14`, icon
+    `w-7 h-7 md:w-8 md:h-8`.
+  - Scroll offset: compute `window.innerWidth < 768 ? 60 : 80` inline inside the
+    click handler (runs on click only, so no render flash, no state needed).
+- **ProjectModal.tsx**: remove `isMobile` state + resize effect; keep the
+  `document.body.overflow` lock effect.
+  - Container `p-0 md:p-4`; box `w-full h-full rounded-none md:max-w-2xl
+    md:h-auto md:max-h-[80vh] md:rounded-xl`.
+  - Image heights, close-button size, paddings, text sizes → `md:` classes.
+  - Mobile-only gradient overlay → `md:hidden`.
+  - Icon sizing via `className` (e.g. `w-5 h-5 md:w-4 md:h-4`) instead of the JS
+    `size` prop, so it is responsive without `isMobile`.
+
+## B. Mobile layout polish
+
+- **More work cards (ProjectsSection)**: `flex flex-col sm:flex-row`; image
+  `w-full h-40 sm:w-1/3 sm:h-auto`; content `w-full sm:w-2/3`. Full-width image
+  on top for phones, side-by-side from `sm`.
+- **Experience timeline (ExperienceSection)**: add a mobile left rail.
+  - A vertical gradient line pinned left on mobile (`md:` keeps the existing
+    centered alternating layout). Each item gets a small dot on the rail and
+    left padding so cards sit to the right of the line.
+  - `space-y-8 md:space-y-16` to tighten mobile rhythm.
+  - Replace the date-pill em dash separator with `to` (also satisfies the
+    no-em-dash preference). Example: `2026-02 to Present`.
+- **Dense architecture diagram (FeaturedProjectCard)**: wrap the detail `<img>`
+  so it stays legible on phones: container `overflow-x-auto`, img
+  `min-w-[760px] sm:min-w-0 w-full h-auto` so it can be panned horizontally on
+  small screens instead of squishing. (The glance and pipeline diagrams already
+  fit; leave them.)
+- **Hero icon links**: enlarge hit area with `p-2 -m-2` (no visual change).
+- **Overflow audit**: confirm no horizontal scroll at 320–414px widths; body
+  already has `overflow-x-hidden`.
+
+## C. Animation pass
+
+Mechanism: reuse `useInView` + Tailwind transition classes. No new deps.
+
+- **More work grid (liveliness focus)**: each card reveals with **fade + slide
+  up + subtle scale (0.97 → 1)**, staggered ~80–100ms per card by index,
+  triggered when the grid enters view. Slightly richer than a plain fade so the
+  section feels alive. Hover stays as is (shadow + lift + image zoom).
+  - Implementation: observe the grid container (or reuse section `isVisible`)
+    and apply per-card `transitionDelay` by index, plus the
+    `opacity/translate-y/scale` classes.
+- **Featured cards**: each card self-reveals via `useInView` (they are large and
+  far apart, like Experience items), with a more restrained fade-up (no scale),
+  so the centerpiece reads as composed rather than bouncy.
+- Durations/easing consistent with the site (`duration-500`–`700`, ease-out,
+  `translate-y` 6–10px).
+
+## Components touched
+
+`HeroSection.tsx`, `ScrollArrow.tsx`, `ProjectModal.tsx`, `ProjectsSection.tsx`,
+`FeaturedProjectCard.tsx`, `ExperienceSection.tsx`. Reuse `hooks/useInView.ts`.
+No data or copy changes except the Experience date separator. No new
+dependencies.
+
+## Verification
+
+- `yarn build` clean, `yarn lint` 0 errors (6 pre-existing ref-cleanup warnings
+  are acceptable; do not introduce new ones).
+- Manual check at mobile widths (375px) and desktop: no load flash on Hero, no
+  horizontal overflow, More work cards stack, Experience rail renders, featured
+  and More work animations fire on scroll.
+
+## Out of scope
+
+Reduced-motion handling; any content/copy rewrites; restructuring sections;
+touching the merged main history.

--- a/src/components/FeaturedProjectCard.tsx
+++ b/src/components/FeaturedProjectCard.tsx
@@ -54,7 +54,7 @@ export default function FeaturedProjectCard({ project, index }: Props) {
     <article
       ref={ref}
       className={`relative bg-white rounded-2xl border border-gray-200 shadow-sm overflow-hidden transition-all duration-300 ${
-        inView ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
+        inView ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
       }`}
     >
       {/* Gradient accent bar */}

--- a/src/components/FeaturedProjectCard.tsx
+++ b/src/components/FeaturedProjectCard.tsx
@@ -1,5 +1,6 @@
 import { FaPlay, FaChevronDown } from "react-icons/fa";
 import type { FeaturedProject } from "../data/featuredProjects";
+import useInView from "../hooks/useInView";
 
 interface Props {
   project: FeaturedProject;
@@ -47,8 +48,15 @@ function DemoVideo({ url, title }: { url: string; title: string }) {
 }
 
 export default function FeaturedProjectCard({ project, index }: Props) {
+  const [ref, inView] = useInView(0.12);
+
   return (
-    <article className="relative bg-white rounded-2xl border border-gray-200 shadow-sm overflow-hidden">
+    <article
+      ref={ref}
+      className={`relative bg-white rounded-2xl border border-gray-200 shadow-sm overflow-hidden transition-all duration-500 ${
+        inView ? "opacity-100 translate-y-0" : "opacity-0 translate-y-6"
+      }`}
+    >
       {/* Gradient accent bar */}
       <div className="h-1.5 w-full bg-gradient-to-r from-purple-600 via-pink-500 to-blue-500" />
 
@@ -90,80 +98,95 @@ export default function FeaturedProjectCard({ project, index }: Props) {
           </p>
         </section>
 
-        {/* Architecture diagram */}
-        {project.diagram && (
-          <section className="mb-8">
-            <h4 className="text-sm font-semibold uppercase tracking-wider text-violet-600 mb-3">
-              Architecture
-            </h4>
-            <div className="rounded-xl border border-gray-200 bg-white p-3 sm:p-4 overflow-x-auto">
-              <img
-                src={project.diagram.src}
-                alt={project.diagram.alt}
-                className="w-full h-auto max-w-3xl mx-auto"
-                loading="lazy"
-              />
-            </div>
+        {/* Full breakdown expander */}
+        <details className="group/breakdown">
+          <summary className="flex items-center justify-between gap-4 cursor-pointer list-none rounded-xl border border-gray-200 px-4 py-3 hover:bg-gray-50 transition-colors">
+            <span className="font-semibold text-violet-600 text-sm uppercase tracking-wider">
+              Show full breakdown
+            </span>
+            <FaChevronDown
+              className="w-3.5 h-3.5 text-gray-400 flex-shrink-0 transition-transform duration-200 group-open/breakdown:rotate-180"
+              aria-hidden="true"
+            />
+          </summary>
 
-            {project.detailDiagram && (
-              <details className="group mt-3 border border-gray-100 rounded-xl">
-                <summary className="flex items-center justify-between gap-4 cursor-pointer list-none px-4 py-3.5 hover:bg-gray-50 rounded-xl transition-colors">
-                  <span className="font-medium text-[#1a1a2e]">
-                    Full architecture (detail)
-                  </span>
-                  <FaChevronDown
-                    className="w-3.5 h-3.5 text-gray-400 flex-shrink-0 transition-transform duration-200 group-open:rotate-180"
-                    aria-hidden="true"
-                  />
-                </summary>
-                <div className="px-4 pb-4 overflow-x-auto">
+          <div className="mt-6">
+            {/* Architecture diagram */}
+            {project.diagram && (
+              <section className="mb-8">
+                <h4 className="text-sm font-semibold uppercase tracking-wider text-violet-600 mb-3">
+                  Architecture
+                </h4>
+                <div className="rounded-xl border border-gray-200 bg-white p-3 sm:p-4 overflow-x-auto">
                   <img
-                    src={project.detailDiagram.src}
-                    alt={project.detailDiagram.alt}
-                    className="w-full h-auto mx-auto"
+                    src={project.diagram.src}
+                    alt={project.diagram.alt}
+                    className="w-full h-auto max-w-3xl mx-auto"
                     loading="lazy"
                   />
                 </div>
-              </details>
+
+                {project.detailDiagram && (
+                  <details className="group mt-3 border border-gray-100 rounded-xl">
+                    <summary className="flex items-center justify-between gap-4 cursor-pointer list-none px-4 py-3.5 hover:bg-gray-50 rounded-xl transition-colors">
+                      <span className="font-medium text-[#1a1a2e]">
+                        Full architecture (detail)
+                      </span>
+                      <FaChevronDown
+                        className="w-3.5 h-3.5 text-gray-400 flex-shrink-0 transition-transform duration-200 group-open:rotate-180"
+                        aria-hidden="true"
+                      />
+                    </summary>
+                    <div className="px-4 pb-4 overflow-x-auto">
+                      <img
+                        src={project.detailDiagram.src}
+                        alt={project.detailDiagram.alt}
+                        className="h-auto mx-auto min-w-[760px] sm:min-w-0 sm:w-full"
+                        loading="lazy"
+                      />
+                    </div>
+                  </details>
+                )}
+              </section>
             )}
-          </section>
-        )}
 
-        {/* Key design decisions — the reasoning */}
-        <section className="mb-8">
-          <h4 className="text-sm font-semibold uppercase tracking-wider text-violet-600 mb-1">
-            Key design decisions
-          </h4>
-          <p className="text-gray-400 text-sm mb-4">
-            The reasoning behind each piece. Click to expand.
-          </p>
-          <div className="divide-y divide-gray-100 border border-gray-100 rounded-xl">
-            {project.designDecisions.map((d) => (
-              <details key={d.title} className="group">
-                <summary className="flex items-center justify-between gap-4 cursor-pointer list-none px-4 py-3.5 hover:bg-gray-50 rounded-xl transition-colors">
-                  <span className="font-medium text-[#1a1a2e]">{d.title}</span>
-                  <FaChevronDown
-                    className="w-3.5 h-3.5 text-gray-400 flex-shrink-0 transition-transform duration-200 group-open:rotate-180"
-                    aria-hidden="true"
-                  />
-                </summary>
-                <p className="px-4 pb-4 -mt-1 text-gray-600 text-sm leading-relaxed">
-                  {d.body}
-                </p>
-              </details>
-            ))}
+            {/* Key design decisions — the reasoning */}
+            <section className="mb-8">
+              <h4 className="text-sm font-semibold uppercase tracking-wider text-violet-600 mb-1">
+                Key design decisions
+              </h4>
+              <p className="text-gray-400 text-sm mb-4">
+                The reasoning behind each piece. Click to expand.
+              </p>
+              <div className="divide-y divide-gray-100 border border-gray-100 rounded-xl">
+                {project.designDecisions.map((d) => (
+                  <details key={d.title} className="group">
+                    <summary className="flex items-center justify-between gap-4 cursor-pointer list-none px-4 py-3.5 hover:bg-gray-50 rounded-xl transition-colors">
+                      <span className="font-medium text-[#1a1a2e]">{d.title}</span>
+                      <FaChevronDown
+                        className="w-3.5 h-3.5 text-gray-400 flex-shrink-0 transition-transform duration-200 group-open:rotate-180"
+                        aria-hidden="true"
+                      />
+                    </summary>
+                    <p className="px-4 pb-4 -mt-1 text-gray-600 text-sm leading-relaxed">
+                      {d.body}
+                    </p>
+                  </details>
+                ))}
+              </div>
+            </section>
+
+            {/* Stack */}
+            <section>
+              <h4 className="text-sm font-semibold uppercase tracking-wider text-violet-600 mb-3">
+                Stack
+              </h4>
+              <p className="text-gray-600 text-sm leading-relaxed max-w-3xl">
+                {project.stack}
+              </p>
+            </section>
           </div>
-        </section>
-
-        {/* Stack */}
-        <section>
-          <h4 className="text-sm font-semibold uppercase tracking-wider text-violet-600 mb-3">
-            Stack
-          </h4>
-          <p className="text-gray-600 text-sm leading-relaxed max-w-3xl">
-            {project.stack}
-          </p>
-        </section>
+        </details>
       </div>
     </article>
   );

--- a/src/components/FeaturedProjectCard.tsx
+++ b/src/components/FeaturedProjectCard.tsx
@@ -53,8 +53,8 @@ export default function FeaturedProjectCard({ project, index }: Props) {
   return (
     <article
       ref={ref}
-      className={`relative bg-white rounded-2xl border border-gray-200 shadow-sm overflow-hidden transition-all duration-500 ${
-        inView ? "opacity-100 translate-y-0" : "opacity-0 translate-y-6"
+      className={`relative bg-white rounded-2xl border border-gray-200 shadow-sm overflow-hidden transition-all duration-300 ${
+        inView ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
       }`}
     >
       {/* Gradient accent bar */}

--- a/src/components/ProjectModal.tsx
+++ b/src/components/ProjectModal.tsx
@@ -15,16 +15,10 @@ const ProjectModal: React.FC<ProjectModalProps> = ({
   isOpen,
 }) => {
   const [mounted, setMounted] = useState(false);
-  const [isMobile, setIsMobile] = useState(false);
 
   useEffect(() => {
     // Verify mounting on client side only
     setMounted(true);
-
-    // Check mobile
-    const checkMobile = () => setIsMobile(window.innerWidth <= 768);
-    checkMobile();
-    window.addEventListener("resize", checkMobile);
 
     if (isOpen) {
       // Prevent scrolling when modal is open
@@ -34,7 +28,6 @@ const ProjectModal: React.FC<ProjectModalProps> = ({
     // Cleanup function
     return () => {
       document.body.style.overflow = "auto";
-      window.removeEventListener("resize", checkMobile);
     };
   }, [isOpen]);
 
@@ -53,9 +46,7 @@ const ProjectModal: React.FC<ProjectModalProps> = ({
   // Modal content
   const modalContent = (
     <div
-      className={`fixed inset-0 z-50 flex items-center justify-center overflow-hidden ${
-        isMobile ? "p-0" : "p-4"
-      }`}
+      className="fixed inset-0 z-50 flex items-center justify-center overflow-hidden p-0 md:p-4"
     >
       <div
         className="fixed inset-0 bg-black/40 backdrop-blur-sm"
@@ -63,11 +54,7 @@ const ProjectModal: React.FC<ProjectModalProps> = ({
       />
 
       <div
-        className={`relative bg-white text-[#1a1a2e] overflow-hidden shadow-2xl ${
-          isMobile
-            ? "w-full h-full rounded-none"
-            : "max-w-2xl w-full max-h-[80vh] rounded-xl"
-        }`}
+        className="relative bg-white text-[#1a1a2e] overflow-hidden shadow-2xl w-full h-full rounded-none md:w-full md:max-w-2xl md:h-auto md:max-h-[80vh] md:rounded-xl"
         role="dialog"
         aria-modal="true"
         aria-labelledby="modal-title"
@@ -78,52 +65,38 @@ const ProjectModal: React.FC<ProjectModalProps> = ({
             <img
               src={image}
               alt={project.title}
-              className={`w-full object-cover object-center ${
-                isMobile ? "h-52" : "h-48"
-              }`}
+              className="w-full object-cover object-center h-52 md:h-48"
             />
             {/* Gradient overlay for mobile */}
-            {isMobile && (
-              <div className="absolute inset-0 bg-gradient-to-t from-white via-transparent to-transparent" />
-            )}
+            <div className="absolute inset-0 bg-gradient-to-t from-white via-transparent to-transparent md:hidden" />
             <button
               onClick={onClose}
-              className={`absolute top-4 right-4 rounded-full bg-white/80 backdrop-blur-sm flex items-center justify-center active:bg-gray-100 transition text-gray-600 shadow-sm ${
-                isMobile ? "w-11 h-11" : "w-8 h-8 hover:bg-gray-100"
-              }`}
+              className="absolute top-4 right-4 rounded-full bg-white/80 backdrop-blur-sm flex items-center justify-center active:bg-gray-100 transition text-gray-600 shadow-sm w-11 h-11 md:w-8 md:h-8 hover:bg-gray-100"
               aria-label="Close modal"
             >
-              <FaTimes size={isMobile ? 20 : 16} />
+              <FaTimes className="w-5 h-5 md:w-4 md:h-4" />
             </button>
           </div>
 
           {/* Content */}
           <div
-            className={`overflow-y-auto flex-grow ${
-              isMobile ? "p-5 pb-8" : "p-5"
-            }`}
+            className="overflow-y-auto flex-grow p-5 pb-8 md:pb-5"
           >
             <h2
               id="modal-title"
-              className={`font-bold mb-2 bg-gradient-to-r from-purple-600 to-pink-500 bg-clip-text text-transparent ${
-                isMobile ? "text-2xl" : "text-xl"
-              }`}
+              className="font-bold mb-2 bg-gradient-to-r from-purple-600 to-pink-500 bg-clip-text text-transparent text-2xl md:text-xl"
             >
               {project.title}
             </h2>
             <p
-              className={`text-gray-600 mb-4 font-medium ${
-                isMobile ? "text-base" : "text-lg"
-              }`}
+              className="text-gray-600 mb-4 font-medium text-base md:text-lg"
             >
               {project.summary}
             </p>
             {project.description.map((desc, index) => (
               <p
                 key={index}
-                className={`text-gray-500 mb-4 ${
-                  isMobile ? "text-base leading-relaxed" : "text-sm"
-                }`}
+                className="text-gray-500 mb-4 text-base leading-relaxed md:text-sm"
               >
                 {desc}
               </p>
@@ -131,21 +104,15 @@ const ProjectModal: React.FC<ProjectModalProps> = ({
 
             <div className="mb-5">
               <h3
-                className={`font-semibold mb-3 text-violet-600 ${
-                  isMobile ? "text-lg" : "text-md"
-                }`}
+                className="font-semibold mb-3 text-violet-600 text-lg md:text-md"
               >
                 Technologies
               </h3>
-              <div className={`flex flex-wrap ${isMobile ? "gap-2" : "gap-1.5"}`}>
+              <div className="flex flex-wrap gap-2 md:gap-1.5">
                 {technologies.map((tech, index) => (
                   <span
                     key={index}
-                    className={`bg-violet-100 text-violet-700 rounded-md flex items-center justify-center whitespace-nowrap ${
-                      isMobile
-                        ? "px-3 py-1.5 text-sm"
-                        : "px-2 py-1 text-xs"
-                    }`}
+                    className="bg-violet-100 text-violet-700 rounded-md flex items-center justify-center whitespace-nowrap px-3 py-1.5 text-sm md:px-2 md:py-1 md:text-xs"
                   >
                     {tech}
                   </span>
@@ -156,16 +123,12 @@ const ProjectModal: React.FC<ProjectModalProps> = ({
             {features.length > 0 && (
               <div className="mb-5">
                 <h3
-                  className={`font-semibold mb-3 text-violet-600 ${
-                    isMobile ? "text-lg" : "text-md"
-                  }`}
+                  className="font-semibold mb-3 text-violet-600 text-lg md:text-md"
                 >
                   Key Features
                 </h3>
                 <ul
-                  className={`list-disc list-inside space-y-2 text-gray-600 ${
-                    isMobile ? "text-base" : "text-sm"
-                  }`}
+                  className="list-disc list-inside space-y-2 text-gray-600 text-base md:text-sm"
                 >
                   {features.map((feature, index) => (
                     <li key={index}>{feature}</li>
@@ -175,20 +138,16 @@ const ProjectModal: React.FC<ProjectModalProps> = ({
             )}
 
             {/* Action buttons */}
-            <div className={`flex gap-3 ${isMobile ? "mt-6" : "mt-3"}`}>
+            <div className="flex gap-3 mt-6 md:mt-3">
               {liveUrl && (
                 <a
                   href={liveUrl}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className={`flex items-center justify-center bg-violet-600 active:bg-violet-700 rounded-full text-white transition ${
-                    isMobile
-                      ? "w-12 h-12 hover:bg-violet-600"
-                      : "w-10 h-10 hover:bg-violet-700"
-                  }`}
+                  className="flex items-center justify-center bg-violet-600 active:bg-violet-700 rounded-full text-white transition w-12 h-12 md:w-10 md:h-10 hover:bg-violet-700"
                   title="View Live Site"
                 >
-                  <FaGlobe size={isMobile ? 20 : 18} />
+                  <FaGlobe className="w-5 h-5 md:w-[18px] md:h-[18px]" />
                 </a>
               )}
               {repoUrl && (
@@ -196,14 +155,10 @@ const ProjectModal: React.FC<ProjectModalProps> = ({
                   href={repoUrl}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className={`flex items-center justify-center border border-violet-600 active:border-violet-700 rounded-full text-violet-600 active:text-violet-500 transition ${
-                    isMobile
-                      ? "w-12 h-12 hover:border-violet-600"
-                      : "w-10 h-10 hover:border-violet-700 hover:text-violet-500"
-                  }`}
+                  className="flex items-center justify-center border border-violet-600 active:border-violet-700 rounded-full text-violet-600 active:text-violet-500 transition w-12 h-12 md:w-10 md:h-10 hover:border-violet-700 hover:text-violet-500"
                   title="View Source Code"
                 >
-                  <FaGithub size={isMobile ? 20 : 18} />
+                  <FaGithub className="w-5 h-5 md:w-[18px] md:h-[18px]" />
                 </a>
               )}
             </div>

--- a/src/components/ScrollArrow.tsx
+++ b/src/components/ScrollArrow.tsx
@@ -1,4 +1,3 @@
-import { useState, useEffect } from "react";
 import { MdOutlineKeyboardArrowDown } from "react-icons/md";
 
 interface ScrollArrowProps {
@@ -8,22 +7,6 @@ interface ScrollArrowProps {
 const SECTION_ORDER = ["hero", "showcase", "about", "experience", "projects", "skills", "contact"];
 
 export default function ScrollArrow({ activeSection }: ScrollArrowProps) {
-  const [isMobile, setIsMobile] = useState(false);
-
-  useEffect(() => {
-    const checkMobile = () => {
-      setIsMobile(window.innerWidth <= 768);
-    };
-
-    // Check on mount
-    checkMobile();
-
-    // Add resize listener
-    window.addEventListener("resize", checkMobile);
-
-    // Cleanup
-    return () => window.removeEventListener("resize", checkMobile);
-  }, []);
 
   const currentIndex = SECTION_ORDER.indexOf(activeSection);
   const nextSection =
@@ -38,7 +21,8 @@ export default function ScrollArrow({ activeSection }: ScrollArrowProps) {
     if (nextElement) {
       const elementRect = nextElement.getBoundingClientRect();
       const absoluteElementTop = window.pageYOffset + elementRect.top;
-      const targetPosition = absoluteElementTop - (isMobile ? 60 : 80);
+      const offset = window.innerWidth < 768 ? 60 : 80;
+      const targetPosition = absoluteElementTop - offset;
 
       const start = window.pageYOffset;
       const distance = targetPosition - start;
@@ -64,21 +48,15 @@ export default function ScrollArrow({ activeSection }: ScrollArrowProps) {
 
   return (
     <div
-      className={`fixed ${
-        isMobile ? "bottom-6" : "bottom-12"
-      } left-1/2 transform -translate-x-1/2 z-40`}
+      className="fixed bottom-6 md:bottom-12 left-1/2 transform -translate-x-1/2 z-40"
     >
       <button
         onClick={handleClick}
-        className={`animate-bounce cursor-pointer transition-all duration-300 group flex items-center justify-center rounded-full bg-violet-100 active:bg-violet-200 shadow-sm ${
-          isMobile ? "w-12 h-12" : "w-14 h-14 hover:bg-violet-200"
-        }`}
+        className="animate-bounce cursor-pointer transition-all duration-300 group flex items-center justify-center rounded-full bg-violet-100 active:bg-violet-200 shadow-sm w-12 h-12 md:w-14 md:h-14 hover:bg-violet-200"
         aria-label="Scroll to next section"
       >
         <MdOutlineKeyboardArrowDown
-          className={`${
-            isMobile ? "w-7 h-7" : "w-8 h-8"
-          } text-violet-500 group-hover:text-violet-600 group-active:text-violet-600 transition-all`}
+          className="w-7 h-7 md:w-8 md:h-8 text-violet-500 group-hover:text-violet-600 group-active:text-violet-600 transition-all"
         />
       </button>
     </div>

--- a/src/hooks/useInView.ts
+++ b/src/hooks/useInView.ts
@@ -28,7 +28,7 @@ export default function useInView(
           setIntersecting(false);
         }
       },
-      { threshold, rootMargin: "0px 0px -10% 0px" }
+      { threshold, rootMargin: "0px 0px 15% 0px" }
     );
 
     observer.observe(element);

--- a/src/hooks/useInView.ts
+++ b/src/hooks/useInView.ts
@@ -28,7 +28,7 @@ export default function useInView(
           setIntersecting(false);
         }
       },
-      { threshold, rootMargin: "0px 0px 15% 0px" }
+      { threshold, rootMargin: "0px" }
     );
 
     observer.observe(element);

--- a/src/hooks/useInView.ts
+++ b/src/hooks/useInView.ts
@@ -1,33 +1,39 @@
 // src/hooks/useInView.ts
 import { useEffect, useRef, useState, RefObject } from "react";
 
+/**
+ * Observe an element's viewport intersection.
+ * @param threshold IntersectionObserver threshold.
+ * @param once When true (default), latch to visible on first intersection and
+ *   stop observing, so a fast scroll-out never re-hides revealed content.
+ */
 export default function useInView(
-  threshold = 0.1
+  threshold = 0.1,
+  once = true
 ): [RefObject<HTMLDivElement | null>, boolean] {
   const [isIntersecting, setIntersecting] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+
     const observer = new IntersectionObserver(
       ([entry]) => {
-        if (entry) {
-          setIntersecting(entry.isIntersecting);
+        if (!entry) return;
+        if (entry.isIntersecting) {
+          setIntersecting(true);
+          if (once) observer.unobserve(element);
+        } else if (!once) {
+          setIntersecting(false);
         }
       },
-      { threshold }
+      { threshold, rootMargin: "0px 0px -10% 0px" }
     );
 
-    const element = ref.current;
-    if (element) {
-      observer.observe(element);
-    }
-
-    return () => {
-      if (element) {
-        observer.unobserve(element);
-      }
-    };
-  }, [threshold]);
+    observer.observe(element);
+    return () => observer.unobserve(element);
+  }, [threshold, once]);
 
   return [ref, isIntersecting];
 }

--- a/src/pages/AboutSection.tsx
+++ b/src/pages/AboutSection.tsx
@@ -12,7 +12,7 @@ export default function AboutSection() {
           observer.disconnect();
         }
       },
-      { threshold: 0, rootMargin: "0px 0px 15% 0px" }
+      { threshold: 0, rootMargin: "0px" }
     );
     if (sectionRef.current) observer.observe(sectionRef.current);
     return () => observer.disconnect();
@@ -22,20 +22,20 @@ export default function AboutSection() {
     <section
       ref={sectionRef}
       className={`w-full transition-all duration-300 ${
-        isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
+        isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
       }`}
     >
       <div className="max-w-4xl mx-auto px-4 sm:px-6">
         <h2
           className={`font-bold text-center mb-6 bg-gradient-to-r from-purple-600 via-pink-500 to-blue-500 bg-clip-text text-transparent transition-all duration-300 ${
-            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
+            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
           } text-4xl md:text-6xl`}
         >
           About Me
         </h2>
         <div
           className={`transition-all duration-300 ${
-            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
+            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
           }`}
         >
           <p className="text-xl md:text-2xl font-semibold text-center text-gray-800 leading-relaxed mb-8 max-w-3xl mx-auto">

--- a/src/pages/AboutSection.tsx
+++ b/src/pages/AboutSection.tsx
@@ -6,32 +6,35 @@ export default function AboutSection() {
 
   useEffect(() => {
     const observer = new IntersectionObserver(
-      ([entry]) => setIsVisible(entry.isIntersecting),
-      { threshold: 0.1, rootMargin: "-100px" }
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true);
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.1, rootMargin: "0px 0px -10% 0px" }
     );
     if (sectionRef.current) observer.observe(sectionRef.current);
-    return () => {
-      if (sectionRef.current) observer.unobserve(sectionRef.current);
-    };
+    return () => observer.disconnect();
   }, []);
 
   return (
     <section
       ref={sectionRef}
-      className={`w-full transition-all duration-1000 ${
+      className={`w-full transition-all duration-500 ${
         isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-10"
       }`}
     >
       <div className="max-w-4xl mx-auto px-4 sm:px-6">
         <h2
-          className={`font-bold text-center mb-6 bg-gradient-to-r from-purple-600 via-pink-500 to-blue-500 bg-clip-text text-transparent transition-all duration-700 delay-200 ${
+          className={`font-bold text-center mb-6 bg-gradient-to-r from-purple-600 via-pink-500 to-blue-500 bg-clip-text text-transparent transition-all duration-500 delay-100 ${
             isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-10"
           } text-4xl md:text-6xl`}
         >
           About Me
         </h2>
         <div
-          className={`transition-all duration-700 delay-500 ${
+          className={`transition-all duration-500 delay-200 ${
             isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-10"
           }`}
         >

--- a/src/pages/AboutSection.tsx
+++ b/src/pages/AboutSection.tsx
@@ -12,7 +12,7 @@ export default function AboutSection() {
           observer.disconnect();
         }
       },
-      { threshold: 0.1, rootMargin: "0px 0px -10% 0px" }
+      { threshold: 0, rootMargin: "0px 0px 15% 0px" }
     );
     if (sectionRef.current) observer.observe(sectionRef.current);
     return () => observer.disconnect();
@@ -21,21 +21,21 @@ export default function AboutSection() {
   return (
     <section
       ref={sectionRef}
-      className={`w-full transition-all duration-500 ${
-        isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-10"
+      className={`w-full transition-all duration-300 ${
+        isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
       }`}
     >
       <div className="max-w-4xl mx-auto px-4 sm:px-6">
         <h2
-          className={`font-bold text-center mb-6 bg-gradient-to-r from-purple-600 via-pink-500 to-blue-500 bg-clip-text text-transparent transition-all duration-500 delay-100 ${
-            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-10"
+          className={`font-bold text-center mb-6 bg-gradient-to-r from-purple-600 via-pink-500 to-blue-500 bg-clip-text text-transparent transition-all duration-300 ${
+            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
           } text-4xl md:text-6xl`}
         >
           About Me
         </h2>
         <div
-          className={`transition-all duration-500 delay-200 ${
-            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-10"
+          className={`transition-all duration-300 ${
+            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
           }`}
         >
           <p className="text-xl md:text-2xl font-semibold text-center text-gray-800 leading-relaxed mb-8 max-w-3xl mx-auto">

--- a/src/pages/ContactSection.tsx
+++ b/src/pages/ContactSection.tsx
@@ -7,13 +7,16 @@ export default function ContactSection() {
 
   useEffect(() => {
     const observer = new IntersectionObserver(
-      ([entry]) => setIsVisible(entry.isIntersecting),
-      { threshold: 0.1, rootMargin: "-100px" }
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true);
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.1, rootMargin: "0px 0px -10% 0px" }
     );
     if (sectionRef.current) observer.observe(sectionRef.current);
-    return () => {
-      if (sectionRef.current) observer.unobserve(sectionRef.current);
-    };
+    return () => observer.disconnect();
   }, []);
 
   const contacts = [
@@ -40,37 +43,40 @@ export default function ContactSection() {
   return (
     <section
       ref={sectionRef}
-      className={`w-full transition-all duration-1000 ${
+      className={`w-full transition-all duration-500 ${
         isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-10"
       }`}
     >
       <div className="max-w-3xl mx-auto px-4 sm:px-6 text-center">
         <h2
-          className={`font-bold mb-6 bg-gradient-to-r from-purple-600 via-pink-500 to-blue-500 bg-clip-text text-transparent transition-all duration-700 delay-200 ${
+          className={`font-bold mb-6 bg-gradient-to-r from-purple-600 via-pink-500 to-blue-500 bg-clip-text text-transparent transition-all duration-500 delay-100 ${
             isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-10"
           } text-4xl md:text-6xl`}
         >
           Let's Connect
         </h2>
         <p
-          className={`text-gray-500 text-lg mb-12 transition-all duration-700 delay-400 ${
+          className={`text-gray-500 text-lg mb-12 transition-all duration-500 delay-150 ${
             isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-10"
           }`}
         >
           Have a project in mind? Let's talk.
         </p>
         <div
-          className={`flex justify-center gap-6 transition-all duration-700 delay-[600ms] ${
+          className={`flex justify-center gap-6 transition-all duration-500 delay-200 ${
             isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-10"
           }`}
         >
-          {contacts.map(({ icon: Icon, label, href, external }) => (
+          {contacts.map(({ icon: Icon, label, href, external }, i) => (
             <a
               key={label}
               href={href}
               target={external ? "_blank" : undefined}
               rel={external ? "noopener noreferrer" : undefined}
-              className="group flex flex-col items-center gap-3"
+              className={`group flex flex-col items-center gap-3 transition-all duration-500 ${
+                isVisible ? "opacity-100 scale-100" : "opacity-0 scale-95"
+              }`}
+              style={{ transitionDelay: isVisible ? `${200 + i * 70}ms` : "0ms" }}
             >
               <div className="w-16 h-16 rounded-full border border-gray-200 flex items-center justify-center group-hover:border-purple-400 group-hover:shadow-lg group-hover:shadow-purple-500/10 group-hover:scale-110 group-active:scale-95 transition-all duration-300">
                 <Icon className="w-6 h-6 text-gray-600 group-hover:text-purple-500 transition-colors" />

--- a/src/pages/ContactSection.tsx
+++ b/src/pages/ContactSection.tsx
@@ -62,11 +62,7 @@ export default function ContactSection() {
         >
           Have a project in mind? Let's talk.
         </p>
-        <div
-          className={`flex justify-center gap-6 transition-all duration-500 delay-200 ${
-            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-10"
-          }`}
-        >
+        <div className="flex justify-center gap-6">
           {contacts.map(({ icon: Icon, label, href, external }, i) => (
             <a
               key={label}

--- a/src/pages/ContactSection.tsx
+++ b/src/pages/ContactSection.tsx
@@ -13,7 +13,7 @@ export default function ContactSection() {
           observer.disconnect();
         }
       },
-      { threshold: 0, rootMargin: "0px 0px 15% 0px" }
+      { threshold: 0, rootMargin: "0px" }
     );
     if (sectionRef.current) observer.observe(sectionRef.current);
     return () => observer.disconnect();
@@ -44,20 +44,20 @@ export default function ContactSection() {
     <section
       ref={sectionRef}
       className={`w-full transition-all duration-300 ${
-        isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
+        isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
       }`}
     >
       <div className="max-w-3xl mx-auto px-4 sm:px-6 text-center">
         <h2
           className={`font-bold mb-6 bg-gradient-to-r from-purple-600 via-pink-500 to-blue-500 bg-clip-text text-transparent transition-all duration-300 ${
-            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
+            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
           } text-4xl md:text-6xl`}
         >
           Let's Connect
         </h2>
         <p
           className={`text-gray-500 text-lg mb-12 transition-all duration-300 ${
-            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
+            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
           }`}
         >
           Have a project in mind? Let's talk.

--- a/src/pages/ContactSection.tsx
+++ b/src/pages/ContactSection.tsx
@@ -13,7 +13,7 @@ export default function ContactSection() {
           observer.disconnect();
         }
       },
-      { threshold: 0.1, rootMargin: "0px 0px -10% 0px" }
+      { threshold: 0, rootMargin: "0px 0px 15% 0px" }
     );
     if (sectionRef.current) observer.observe(sectionRef.current);
     return () => observer.disconnect();
@@ -43,21 +43,21 @@ export default function ContactSection() {
   return (
     <section
       ref={sectionRef}
-      className={`w-full transition-all duration-500 ${
-        isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-10"
+      className={`w-full transition-all duration-300 ${
+        isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
       }`}
     >
       <div className="max-w-3xl mx-auto px-4 sm:px-6 text-center">
         <h2
-          className={`font-bold mb-6 bg-gradient-to-r from-purple-600 via-pink-500 to-blue-500 bg-clip-text text-transparent transition-all duration-500 delay-100 ${
-            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-10"
+          className={`font-bold mb-6 bg-gradient-to-r from-purple-600 via-pink-500 to-blue-500 bg-clip-text text-transparent transition-all duration-300 ${
+            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
           } text-4xl md:text-6xl`}
         >
           Let's Connect
         </h2>
         <p
-          className={`text-gray-500 text-lg mb-12 transition-all duration-500 delay-150 ${
-            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-10"
+          className={`text-gray-500 text-lg mb-12 transition-all duration-300 ${
+            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
           }`}
         >
           Have a project in mind? Let's talk.
@@ -69,10 +69,10 @@ export default function ContactSection() {
               href={href}
               target={external ? "_blank" : undefined}
               rel={external ? "noopener noreferrer" : undefined}
-              className={`group flex flex-col items-center gap-3 transition-all duration-500 ${
+              className={`group flex flex-col items-center gap-3 transition-all duration-300 ${
                 isVisible ? "opacity-100 scale-100" : "opacity-0 scale-95"
               }`}
-              style={{ transitionDelay: isVisible ? `${200 + i * 70}ms` : "0ms" }}
+              style={{ transitionDelay: isVisible ? `${i * 50}ms` : "0ms" }}
             >
               <div className="w-16 h-16 rounded-full border border-gray-200 flex items-center justify-center group-hover:border-purple-400 group-hover:shadow-lg group-hover:shadow-purple-500/10 group-hover:scale-110 group-active:scale-95 transition-all duration-300">
                 <Icon className="w-6 h-6 text-gray-600 group-hover:text-purple-500 transition-colors" />

--- a/src/pages/ExperienceSection.tsx
+++ b/src/pages/ExperienceSection.tsx
@@ -28,7 +28,11 @@ export default function ExperienceSection() {
 
   useEffect(() => {
     const observer = new IntersectionObserver(
-      ([entry]) => setIsVisible(entry.isIntersecting),
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true);
+        }
+      },
       { threshold: 0.1, rootMargin: "-100px" }
     );
     if (sectionRef.current) observer.observe(sectionRef.current);
@@ -55,14 +59,14 @@ export default function ExperienceSection() {
       if (!el) return;
       const obs = new IntersectionObserver(
         ([entry]) => {
+          if (!entry.isIntersecting) return;
           setRevealed((state) => {
             const next =
-              state.length === items.length
-                ? [...state]
-                : Array(items.length).fill(false);
-            next[idx] = entry.isIntersecting;
+              state.length === items.length ? [...state] : Array(items.length).fill(false);
+            next[idx] = true;
             return next;
           });
+          obs.unobserve(el);
         },
         { threshold: 0.2, rootMargin: "0px 0px -10% 0px" }
       );
@@ -75,21 +79,23 @@ export default function ExperienceSection() {
   return (
     <section
       ref={sectionRef}
-      className={`w-full transition-all duration-1000 ${
+      className={`w-full transition-all duration-500 ${
         isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-10"
       }`}
     >
       <div className="max-w-5xl mx-auto px-4 sm:px-6">
         <h2
-          className={`font-bold text-center mb-16 bg-gradient-to-r from-purple-600 via-pink-500 to-blue-500 bg-clip-text text-transparent transition-all duration-700 delay-200 ${
+          className={`font-bold text-center mb-16 bg-gradient-to-r from-purple-600 via-pink-500 to-blue-500 bg-clip-text text-transparent transition-all duration-500 delay-100 ${
             isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-10"
           } text-4xl md:text-6xl`}
         >
           Experience
         </h2>
 
-        <div className="relative space-y-16">
-          {/* Decorative center line */}
+        <div className="relative space-y-8 md:space-y-16">
+          {/* Mobile left rail */}
+          <div className="absolute left-[7px] top-2 bottom-2 w-px bg-gradient-to-b from-purple-300 via-pink-300 to-transparent md:hidden" />
+          {/* Desktop center line */}
           <div className="absolute left-1/2 -translate-x-1/2 top-0 bottom-0 w-px bg-gradient-to-b from-purple-300 via-pink-300 to-transparent hidden md:block" />
 
           {items.map((item, index) => {
@@ -100,12 +106,13 @@ export default function ExperienceSection() {
                 ref={(el) => {
                   itemRefs.current[index] = el;
                 }}
-                className={`flex flex-col md:flex-row items-center gap-8 transition-all duration-700 ${
+                className={`relative pl-6 md:pl-0 flex flex-col md:flex-row items-center gap-8 transition-all duration-500 ${
                   revealed[index]
                     ? "opacity-100 translate-y-0"
                     : "opacity-0 translate-y-8"
                 }`}
               >
+                <span className="absolute left-0 top-2 w-3.5 h-3.5 rounded-full bg-white border-2 border-purple-400 md:hidden" />
                 {/* Spacer for alternating layout */}
                 {!isLeft && <div className="hidden md:block md:w-1/2" />}
 
@@ -117,7 +124,7 @@ export default function ExperienceSection() {
                         {item.title}
                       </h3>
                       <span className="px-3 py-1 text-xs font-medium bg-purple-100 text-purple-700 rounded-full whitespace-nowrap">
-                        {item.start} — {item.end}
+                        {item.start} to {item.end}
                       </span>
                     </div>
                     <p className="text-gray-500 text-sm mb-4">

--- a/src/pages/ExperienceSection.tsx
+++ b/src/pages/ExperienceSection.tsx
@@ -34,7 +34,7 @@ export default function ExperienceSection() {
           observer.disconnect();
         }
       },
-      { threshold: 0, rootMargin: "0px 0px 15% 0px" }
+      { threshold: 0, rootMargin: "0px" }
     );
     if (sectionRef.current) observer.observe(sectionRef.current);
     return () => observer.disconnect();
@@ -67,7 +67,7 @@ export default function ExperienceSection() {
           });
           obs.unobserve(el);
         },
-        { threshold: 0, rootMargin: "0px 0px 10% 0px" }
+        { threshold: 0, rootMargin: "0px" }
       );
       obs.observe(el);
       observers.push(obs);
@@ -79,13 +79,13 @@ export default function ExperienceSection() {
     <section
       ref={sectionRef}
       className={`w-full transition-all duration-300 ${
-        isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
+        isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
       }`}
     >
       <div className="max-w-5xl mx-auto px-4 sm:px-6">
         <h2
           className={`font-bold text-center mb-16 bg-gradient-to-r from-purple-600 via-pink-500 to-blue-500 bg-clip-text text-transparent transition-all duration-300 ${
-            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
+            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
           } text-4xl md:text-6xl`}
         >
           Experience
@@ -108,7 +108,7 @@ export default function ExperienceSection() {
                 className={`relative pl-6 md:pl-0 flex flex-col md:flex-row items-center gap-8 transition-all duration-300 ${
                   revealed[index]
                     ? "opacity-100 translate-y-0"
-                    : "opacity-0 translate-y-2"
+                    : "opacity-0 translate-y-4"
                 }`}
               >
                 <span className="absolute left-0 top-2 w-3.5 h-3.5 rounded-full bg-white border-2 border-purple-400 md:hidden" />

--- a/src/pages/ExperienceSection.tsx
+++ b/src/pages/ExperienceSection.tsx
@@ -34,7 +34,7 @@ export default function ExperienceSection() {
           observer.disconnect();
         }
       },
-      { threshold: 0.1, rootMargin: "-100px" }
+      { threshold: 0, rootMargin: "0px 0px 15% 0px" }
     );
     if (sectionRef.current) observer.observe(sectionRef.current);
     return () => observer.disconnect();
@@ -67,7 +67,7 @@ export default function ExperienceSection() {
           });
           obs.unobserve(el);
         },
-        { threshold: 0.2, rootMargin: "0px 0px -10% 0px" }
+        { threshold: 0, rootMargin: "0px 0px 10% 0px" }
       );
       obs.observe(el);
       observers.push(obs);
@@ -78,14 +78,14 @@ export default function ExperienceSection() {
   return (
     <section
       ref={sectionRef}
-      className={`w-full transition-all duration-500 ${
-        isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-10"
+      className={`w-full transition-all duration-300 ${
+        isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
       }`}
     >
       <div className="max-w-5xl mx-auto px-4 sm:px-6">
         <h2
-          className={`font-bold text-center mb-16 bg-gradient-to-r from-purple-600 via-pink-500 to-blue-500 bg-clip-text text-transparent transition-all duration-500 delay-100 ${
-            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-10"
+          className={`font-bold text-center mb-16 bg-gradient-to-r from-purple-600 via-pink-500 to-blue-500 bg-clip-text text-transparent transition-all duration-300 ${
+            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
           } text-4xl md:text-6xl`}
         >
           Experience
@@ -105,10 +105,10 @@ export default function ExperienceSection() {
                 ref={(el) => {
                   itemRefs.current[index] = el;
                 }}
-                className={`relative pl-6 md:pl-0 flex flex-col md:flex-row items-center gap-8 transition-all duration-500 ${
+                className={`relative pl-6 md:pl-0 flex flex-col md:flex-row items-center gap-8 transition-all duration-300 ${
                   revealed[index]
                     ? "opacity-100 translate-y-0"
-                    : "opacity-0 translate-y-8"
+                    : "opacity-0 translate-y-2"
                 }`}
               >
                 <span className="absolute left-0 top-2 w-3.5 h-3.5 rounded-full bg-white border-2 border-purple-400 md:hidden" />

--- a/src/pages/ExperienceSection.tsx
+++ b/src/pages/ExperienceSection.tsx
@@ -31,14 +31,13 @@ export default function ExperienceSection() {
       ([entry]) => {
         if (entry.isIntersecting) {
           setIsVisible(true);
+          observer.disconnect();
         }
       },
       { threshold: 0.1, rootMargin: "-100px" }
     );
     if (sectionRef.current) observer.observe(sectionRef.current);
-    return () => {
-      if (sectionRef.current) observer.unobserve(sectionRef.current);
-    };
+    return () => observer.disconnect();
   }, []);
 
   const items: ExperienceItem[] = [...(experience as ExperienceItem[])].sort(

--- a/src/pages/HeroSection.tsx
+++ b/src/pages/HeroSection.tsx
@@ -3,15 +3,7 @@ import { FaGithub, FaEnvelope, FaLinkedinIn, FaArrowDown } from "react-icons/fa"
 
 export default function HeroSection() {
   const [isVisible, setIsVisible] = useState(false);
-  const [isMobile, setIsMobile] = useState(false);
   const sectionRef = useRef<HTMLElement>(null);
-
-  useEffect(() => {
-    const checkMobile = () => setIsMobile(window.innerWidth <= 768);
-    checkMobile();
-    window.addEventListener("resize", checkMobile);
-    return () => window.removeEventListener("resize", checkMobile);
-  }, []);
 
   useEffect(() => {
     const observer = new IntersectionObserver(
@@ -35,11 +27,7 @@ export default function HeroSection() {
   return (
     <section
       ref={sectionRef}
-      className="w-full relative overflow-hidden"
-      style={{
-        height: isMobile ? "calc(100dvh - 56px)" : "100vh",
-        minHeight: isMobile ? "calc(100dvh - 56px)" : "100vh",
-      }}
+      className="w-full relative overflow-hidden h-[calc(100dvh-56px)] min-h-[calc(100dvh-56px)] md:h-screen md:min-h-screen"
     >
       {/* Animated gradient mesh background (CSS only) */}
       <div className="absolute inset-0 overflow-hidden">
@@ -60,14 +48,14 @@ export default function HeroSection() {
         <h1
           className={`font-bold bg-gradient-to-r from-purple-600 via-pink-500 to-blue-500 bg-clip-text text-transparent leading-tight mb-6 transition-all duration-700 delay-300 ${
             isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-6"
-          } ${isMobile ? "text-5xl" : "text-7xl lg:text-8xl"}`}
+          } text-5xl md:text-7xl lg:text-8xl`}
         >
           Erica Kim
         </h1>
         <p
           className={`text-gray-600 max-w-xl leading-relaxed mb-8 transition-all duration-700 delay-500 ${
             isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-6"
-          } ${isMobile ? "text-base px-4" : "text-lg"}`}
+          } text-base px-4 md:text-lg md:px-0`}
         >
           I design agentic AI systems: tool-use extraction, LLM pipelines, and
           human-in-the-loop approval. I build the full stack around them.
@@ -107,14 +95,14 @@ export default function HeroSection() {
             target="_blank"
             rel="noopener noreferrer"
             aria-label="GitHub"
-            className="text-gray-500 hover:text-purple-600 active:scale-95 transition-colors"
+            className="text-gray-500 hover:text-purple-600 active:scale-95 transition-colors p-2 -m-2"
           >
             <FaGithub className="w-6 h-6" />
           </a>
           <a
             href="mailto:yoohyunk20@gmail.com"
             aria-label="Email"
-            className="text-gray-500 hover:text-purple-600 active:scale-95 transition-colors"
+            className="text-gray-500 hover:text-purple-600 active:scale-95 transition-colors p-2 -m-2"
           >
             <FaEnvelope className="w-6 h-6" />
           </a>
@@ -123,7 +111,7 @@ export default function HeroSection() {
             target="_blank"
             rel="noopener noreferrer"
             aria-label="LinkedIn"
-            className="text-gray-500 hover:text-purple-600 active:scale-95 transition-colors"
+            className="text-gray-500 hover:text-purple-600 active:scale-95 transition-colors p-2 -m-2"
           >
             <FaLinkedinIn className="w-6 h-6" />
           </a>

--- a/src/pages/HeroSection.tsx
+++ b/src/pages/HeroSection.tsx
@@ -13,7 +13,7 @@ export default function HeroSection() {
           observer.disconnect();
         }
       },
-      { threshold: 0.1, rootMargin: "0px 0px -10% 0px" }
+      { threshold: 0, rootMargin: "0px 0px 15% 0px" }
     );
     if (sectionRef.current) observer.observe(sectionRef.current);
     return () => observer.disconnect();
@@ -42,22 +42,22 @@ export default function HeroSection() {
       {/* Content */}
       <div className="relative h-full flex flex-col items-center justify-center px-4 sm:px-6 text-center">
         <p
-          className={`text-gray-500 font-medium mb-4 tracking-wide uppercase text-sm transition-all duration-700 delay-200 ${
-            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-6"
+          className={`text-gray-500 font-medium mb-4 tracking-wide uppercase text-sm transition-all duration-300 ${
+            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
           }`}
         >
           AI Builder · Full-stack
         </p>
         <h1
-          className={`font-bold bg-gradient-to-r from-purple-600 via-pink-500 to-blue-500 bg-clip-text text-transparent leading-tight mb-6 transition-all duration-700 delay-300 ${
-            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-6"
+          className={`font-bold bg-gradient-to-r from-purple-600 via-pink-500 to-blue-500 bg-clip-text text-transparent leading-tight mb-6 transition-all duration-300 ${
+            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
           } text-5xl md:text-7xl lg:text-8xl`}
         >
           Erica Kim
         </h1>
         <p
-          className={`text-gray-600 max-w-xl leading-relaxed mb-8 transition-all duration-700 delay-500 ${
-            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-6"
+          className={`text-gray-600 max-w-xl leading-relaxed mb-8 transition-all duration-300 ${
+            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
           } text-base px-4 md:text-lg md:px-0`}
         >
           I design agentic AI systems: tool-use extraction, LLM pipelines, and
@@ -66,8 +66,8 @@ export default function HeroSection() {
 
         {/* Primary actions */}
         <div
-          className={`flex flex-wrap items-center justify-center gap-4 transition-all duration-700 delay-[600ms] ${
-            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-6"
+          className={`flex flex-wrap items-center justify-center gap-4 transition-all duration-300 ${
+            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
           }`}
         >
           <button
@@ -89,8 +89,8 @@ export default function HeroSection() {
 
         {/* Recruiter shortcuts */}
         <div
-          className={`flex items-center justify-center gap-5 mt-8 transition-all duration-700 delay-[750ms] ${
-            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-6"
+          className={`flex items-center justify-center gap-5 mt-8 transition-all duration-300 ${
+            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
           }`}
         >
           <a

--- a/src/pages/HeroSection.tsx
+++ b/src/pages/HeroSection.tsx
@@ -7,13 +7,16 @@ export default function HeroSection() {
 
   useEffect(() => {
     const observer = new IntersectionObserver(
-      ([entry]) => setIsVisible(entry.isIntersecting),
-      { threshold: 0.1 }
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true);
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.1, rootMargin: "0px 0px -10% 0px" }
     );
     if (sectionRef.current) observer.observe(sectionRef.current);
-    return () => {
-      if (sectionRef.current) observer.unobserve(sectionRef.current);
-    };
+    return () => observer.disconnect();
   }, []);
 
   const handleScrollToProjects = () => {

--- a/src/pages/HeroSection.tsx
+++ b/src/pages/HeroSection.tsx
@@ -13,7 +13,7 @@ export default function HeroSection() {
           observer.disconnect();
         }
       },
-      { threshold: 0, rootMargin: "0px 0px 15% 0px" }
+      { threshold: 0, rootMargin: "0px" }
     );
     if (sectionRef.current) observer.observe(sectionRef.current);
     return () => observer.disconnect();
@@ -43,21 +43,21 @@ export default function HeroSection() {
       <div className="relative h-full flex flex-col items-center justify-center px-4 sm:px-6 text-center">
         <p
           className={`text-gray-500 font-medium mb-4 tracking-wide uppercase text-sm transition-all duration-300 ${
-            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
+            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
           }`}
         >
           AI Builder · Full-stack
         </p>
         <h1
           className={`font-bold bg-gradient-to-r from-purple-600 via-pink-500 to-blue-500 bg-clip-text text-transparent leading-tight mb-6 transition-all duration-300 ${
-            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
+            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
           } text-5xl md:text-7xl lg:text-8xl`}
         >
           Erica Kim
         </h1>
         <p
           className={`text-gray-600 max-w-xl leading-relaxed mb-8 transition-all duration-300 ${
-            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
+            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
           } text-base px-4 md:text-lg md:px-0`}
         >
           I design agentic AI systems: tool-use extraction, LLM pipelines, and
@@ -67,7 +67,7 @@ export default function HeroSection() {
         {/* Primary actions */}
         <div
           className={`flex flex-wrap items-center justify-center gap-4 transition-all duration-300 ${
-            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
+            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
           }`}
         >
           <button
@@ -90,7 +90,7 @@ export default function HeroSection() {
         {/* Recruiter shortcuts */}
         <div
           className={`flex items-center justify-center gap-5 mt-8 transition-all duration-300 ${
-            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
+            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
           }`}
         >
           <a

--- a/src/pages/ProjectsSection.tsx
+++ b/src/pages/ProjectsSection.tsx
@@ -11,8 +11,10 @@ export default function ProjectsSection() {
 
   useEffect(() => {
     const observer = new IntersectionObserver(
-      ([entry]) => setIsVisible(entry.isIntersecting),
-      { threshold: 0.05, rootMargin: "-80px" }
+      ([entry]) => {
+        if (entry.isIntersecting) setIsVisible(true);
+      },
+      { threshold: 0.05, rootMargin: "0px 0px -10% 0px" }
     );
     if (sectionRef.current) observer.observe(sectionRef.current);
     return () => {
@@ -23,7 +25,7 @@ export default function ProjectsSection() {
   return (
     <section
       ref={sectionRef}
-      className={`w-full transition-all duration-1000 ${
+      className={`w-full transition-all duration-500 ${
         isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-10"
       }`}
     >
@@ -60,9 +62,10 @@ export default function ProjectsSection() {
                 key={project.title}
                 type="button"
                 onClick={() => setSelectedIndex(index)}
-                className="group text-left bg-white rounded-xl overflow-hidden border border-gray-100 shadow-sm hover:shadow-md hover:-translate-y-0.5 transition-all duration-300 flex"
+                className={`group text-left bg-white rounded-xl overflow-hidden border border-gray-100 shadow-sm hover:shadow-md hover:-translate-y-0.5 transition-all duration-300 flex flex-col sm:flex-row ${isVisible ? "opacity-100 translate-y-0 scale-100" : "opacity-0 translate-y-4 scale-[0.97]"}`}
+                style={{ transitionDelay: isVisible ? `${Math.min(index * 70, 280)}ms` : "0ms" }}
               >
-                <div className="relative overflow-hidden w-1/3 min-h-full">
+                <div className="relative overflow-hidden w-full h-40 sm:w-1/3 sm:h-auto sm:min-h-full">
                   <img
                     src={image}
                     alt={project.title}
@@ -70,7 +73,7 @@ export default function ProjectsSection() {
                     className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
                   />
                 </div>
-                <div className="p-4 flex flex-col justify-center w-2/3">
+                <div className="p-4 flex flex-col justify-center w-full sm:w-2/3">
                   <h4 className="font-bold text-[#1a1a2e] mb-1 group-hover:text-violet-600 transition-colors">
                     {project.title}
                   </h4>

--- a/src/pages/ProjectsSection.tsx
+++ b/src/pages/ProjectsSection.tsx
@@ -17,7 +17,7 @@ export default function ProjectsSection() {
           observer.disconnect();
         }
       },
-      { threshold: 0.05, rootMargin: "0px 0px -10% 0px" }
+      { threshold: 0, rootMargin: "0px 0px 15% 0px" }
     );
     if (sectionRef.current) observer.observe(sectionRef.current);
     return () => observer.disconnect();
@@ -26,8 +26,8 @@ export default function ProjectsSection() {
   return (
     <section
       ref={sectionRef}
-      className={`w-full transition-all duration-500 ${
-        isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-10"
+      className={`w-full transition-all duration-300 ${
+        isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
       }`}
     >
       <div className="max-w-5xl mx-auto px-4 sm:px-6">
@@ -63,8 +63,8 @@ export default function ProjectsSection() {
                 key={project.title}
                 type="button"
                 onClick={() => setSelectedIndex(index)}
-                className={`group text-left bg-white rounded-xl overflow-hidden border border-gray-100 shadow-sm hover:shadow-md hover:-translate-y-0.5 transition-all duration-300 flex flex-col sm:flex-row ${isVisible ? "opacity-100 translate-y-0 scale-100" : "opacity-0 translate-y-4 scale-[0.97]"}`}
-                style={{ transitionDelay: isVisible ? `${Math.min(index * 70, 280)}ms` : "0ms" }}
+                className={`group text-left bg-white rounded-xl overflow-hidden border border-gray-100 shadow-sm hover:shadow-md hover:-translate-y-0.5 transition-all duration-300 flex flex-col sm:flex-row ${isVisible ? "opacity-100 translate-y-0 scale-100" : "opacity-0 translate-y-2 scale-[0.97]"}`}
+                style={{ transitionDelay: isVisible ? `${Math.min(index * 40, 160)}ms` : "0ms" }}
               >
                 <div className="relative overflow-hidden w-full h-40 sm:w-1/3 sm:h-auto sm:min-h-full">
                   <img

--- a/src/pages/ProjectsSection.tsx
+++ b/src/pages/ProjectsSection.tsx
@@ -12,14 +12,15 @@ export default function ProjectsSection() {
   useEffect(() => {
     const observer = new IntersectionObserver(
       ([entry]) => {
-        if (entry.isIntersecting) setIsVisible(true);
+        if (entry.isIntersecting) {
+          setIsVisible(true);
+          observer.disconnect();
+        }
       },
       { threshold: 0.05, rootMargin: "0px 0px -10% 0px" }
     );
     if (sectionRef.current) observer.observe(sectionRef.current);
-    return () => {
-      if (sectionRef.current) observer.unobserve(sectionRef.current);
-    };
+    return () => observer.disconnect();
   }, []);
 
   return (

--- a/src/pages/ProjectsSection.tsx
+++ b/src/pages/ProjectsSection.tsx
@@ -17,7 +17,7 @@ export default function ProjectsSection() {
           observer.disconnect();
         }
       },
-      { threshold: 0, rootMargin: "0px 0px 15% 0px" }
+      { threshold: 0, rootMargin: "0px" }
     );
     if (sectionRef.current) observer.observe(sectionRef.current);
     return () => observer.disconnect();
@@ -27,7 +27,7 @@ export default function ProjectsSection() {
     <section
       ref={sectionRef}
       className={`w-full transition-all duration-300 ${
-        isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
+        isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
       }`}
     >
       <div className="max-w-5xl mx-auto px-4 sm:px-6">
@@ -63,7 +63,7 @@ export default function ProjectsSection() {
                 key={project.title}
                 type="button"
                 onClick={() => setSelectedIndex(index)}
-                className={`group text-left bg-white rounded-xl overflow-hidden border border-gray-100 shadow-sm hover:shadow-md hover:-translate-y-0.5 transition-all duration-300 flex flex-col sm:flex-row ${isVisible ? "opacity-100 translate-y-0 scale-100" : "opacity-0 translate-y-2 scale-[0.97]"}`}
+                className={`group text-left bg-white rounded-xl overflow-hidden border border-gray-100 shadow-sm hover:shadow-md hover:-translate-y-0.5 transition-all duration-300 flex flex-col sm:flex-row ${isVisible ? "opacity-100 translate-y-0 scale-100" : "opacity-0 translate-y-4 scale-[0.97]"}`}
                 style={{ transitionDelay: isVisible ? `${Math.min(index * 40, 160)}ms` : "0ms" }}
               >
                 <div className="relative overflow-hidden w-full h-40 sm:w-1/3 sm:h-auto sm:min-h-full">

--- a/src/pages/SkillsSection.tsx
+++ b/src/pages/SkillsSection.tsx
@@ -16,7 +16,7 @@ export default function SkillsSection() {
           observer.disconnect();
         }
       },
-      { threshold: 0, rootMargin: "0px 0px 15% 0px" }
+      { threshold: 0, rootMargin: "0px" }
     );
     if (sectionRef.current) observer.observe(sectionRef.current);
     return () => observer.disconnect();
@@ -26,20 +26,20 @@ export default function SkillsSection() {
     <section
       ref={sectionRef}
       className={`w-full bg-[#fafafa] transition-all duration-300 ${
-        isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
+        isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
       }`}
     >
       <div className="max-w-5xl mx-auto px-4 sm:px-6 py-24 md:py-32">
         <h2
           className={`font-bold text-center mb-4 bg-gradient-to-r from-purple-600 via-pink-500 to-blue-500 bg-clip-text text-transparent transition-all duration-300 ${
-            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
+            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
           } text-4xl md:text-6xl`}
         >
           Tools & Technologies
         </h2>
         <p
           className={`text-gray-500 text-center text-base md:text-lg mb-16 max-w-2xl mx-auto transition-all duration-300 ${
-            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
+            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
           }`}
         >
           I mostly write tested code in the JavaScript and Python ecosystems,
@@ -51,7 +51,7 @@ export default function SkillsSection() {
             <div
               key={category.name}
               className={`transition-all duration-300 ${
-                isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
+                isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-4"
               }`}
               style={{
                 transitionDelay: isVisible ? `${Math.min(catIndex * 40, 120)}ms` : "0ms",
@@ -67,7 +67,7 @@ export default function SkillsSection() {
                     className={`transition-all duration-300 ${
                       isVisible
                         ? "opacity-100 translate-y-0"
-                        : "opacity-0 translate-y-2"
+                        : "opacity-0 translate-y-4"
                     }`}
                     style={{
                       transitionDelay: isVisible

--- a/src/pages/SkillsSection.tsx
+++ b/src/pages/SkillsSection.tsx
@@ -10,32 +10,35 @@ export default function SkillsSection() {
 
   useEffect(() => {
     const observer = new IntersectionObserver(
-      ([entry]) => setIsVisible(entry.isIntersecting),
-      { threshold: 0.1, rootMargin: "-100px" }
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setIsVisible(true);
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.1, rootMargin: "0px 0px -10% 0px" }
     );
     if (sectionRef.current) observer.observe(sectionRef.current);
-    return () => {
-      if (sectionRef.current) observer.unobserve(sectionRef.current);
-    };
+    return () => observer.disconnect();
   }, []);
 
   return (
     <section
       ref={sectionRef}
-      className={`w-full bg-[#fafafa] transition-all duration-1000 ${
+      className={`w-full bg-[#fafafa] transition-all duration-500 ${
         isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-10"
       }`}
     >
       <div className="max-w-5xl mx-auto px-4 sm:px-6 py-24 md:py-32">
         <h2
-          className={`font-bold text-center mb-4 bg-gradient-to-r from-purple-600 via-pink-500 to-blue-500 bg-clip-text text-transparent transition-all duration-700 delay-200 ${
+          className={`font-bold text-center mb-4 bg-gradient-to-r from-purple-600 via-pink-500 to-blue-500 bg-clip-text text-transparent transition-all duration-500 delay-100 ${
             isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-10"
           } text-4xl md:text-6xl`}
         >
           Tools & Technologies
         </h2>
         <p
-          className={`text-gray-500 text-center text-base md:text-lg mb-16 max-w-2xl mx-auto transition-all duration-700 delay-400 ${
+          className={`text-gray-500 text-center text-base md:text-lg mb-16 max-w-2xl mx-auto transition-all duration-500 delay-150 ${
             isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-10"
           }`}
         >
@@ -47,11 +50,11 @@ export default function SkillsSection() {
           {categories.map((category, catIndex) => (
             <div
               key={category.name}
-              className={`transition-all duration-700 ${
+              className={`transition-all duration-500 ${
                 isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-10"
               }`}
               style={{
-                transitionDelay: isVisible ? `${600 + catIndex * 200}ms` : "0ms",
+                transitionDelay: isVisible ? `${Math.min(catIndex * 80, 240)}ms` : "0ms",
               }}
             >
               <h3 className="text-lg font-semibold bg-gradient-to-r from-purple-600 to-pink-500 bg-clip-text text-transparent mb-6 text-center">
@@ -68,7 +71,7 @@ export default function SkillsSection() {
                     }`}
                     style={{
                       transitionDelay: isVisible
-                        ? `${800 + catIndex * 200 + skillIndex * 80}ms`
+                        ? `${Math.min(catIndex * 80 + skillIndex * 40, 300)}ms`
                         : "0ms",
                     }}
                   >

--- a/src/pages/SkillsSection.tsx
+++ b/src/pages/SkillsSection.tsx
@@ -16,7 +16,7 @@ export default function SkillsSection() {
           observer.disconnect();
         }
       },
-      { threshold: 0.1, rootMargin: "0px 0px -10% 0px" }
+      { threshold: 0, rootMargin: "0px 0px 15% 0px" }
     );
     if (sectionRef.current) observer.observe(sectionRef.current);
     return () => observer.disconnect();
@@ -25,21 +25,21 @@ export default function SkillsSection() {
   return (
     <section
       ref={sectionRef}
-      className={`w-full bg-[#fafafa] transition-all duration-500 ${
-        isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-10"
+      className={`w-full bg-[#fafafa] transition-all duration-300 ${
+        isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
       }`}
     >
       <div className="max-w-5xl mx-auto px-4 sm:px-6 py-24 md:py-32">
         <h2
-          className={`font-bold text-center mb-4 bg-gradient-to-r from-purple-600 via-pink-500 to-blue-500 bg-clip-text text-transparent transition-all duration-500 delay-100 ${
-            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-10"
+          className={`font-bold text-center mb-4 bg-gradient-to-r from-purple-600 via-pink-500 to-blue-500 bg-clip-text text-transparent transition-all duration-300 ${
+            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
           } text-4xl md:text-6xl`}
         >
           Tools & Technologies
         </h2>
         <p
-          className={`text-gray-500 text-center text-base md:text-lg mb-16 max-w-2xl mx-auto transition-all duration-500 delay-150 ${
-            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-10"
+          className={`text-gray-500 text-center text-base md:text-lg mb-16 max-w-2xl mx-auto transition-all duration-300 ${
+            isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
           }`}
         >
           I mostly write tested code in the JavaScript and Python ecosystems,
@@ -50,11 +50,11 @@ export default function SkillsSection() {
           {categories.map((category, catIndex) => (
             <div
               key={category.name}
-              className={`transition-all duration-500 ${
-                isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-10"
+              className={`transition-all duration-300 ${
+                isVisible ? "opacity-100 translate-y-0" : "opacity-0 translate-y-2"
               }`}
               style={{
-                transitionDelay: isVisible ? `${Math.min(catIndex * 80, 240)}ms` : "0ms",
+                transitionDelay: isVisible ? `${Math.min(catIndex * 40, 120)}ms` : "0ms",
               }}
             >
               <h3 className="text-lg font-semibold bg-gradient-to-r from-purple-600 to-pink-500 bg-clip-text text-transparent mb-6 text-center">
@@ -64,14 +64,14 @@ export default function SkillsSection() {
                 {category.skills.map((skill, skillIndex) => (
                   <div
                     key={skill.name}
-                    className={`transition-all duration-500 ${
+                    className={`transition-all duration-300 ${
                       isVisible
                         ? "opacity-100 translate-y-0"
-                        : "opacity-0 translate-y-6"
+                        : "opacity-0 translate-y-2"
                     }`}
                     style={{
                       transitionDelay: isVisible
-                        ? `${Math.min(catIndex * 80 + skillIndex * 40, 300)}ms`
+                        ? `${Math.min(catIndex * 40 + skillIndex * 20, 140)}ms`
                         : "0ms",
                     }}
                   >


### PR DESCRIPTION
Mobile responsiveness polish and an animation pass across the portfolio. Follows the spec/plan in `docs/superpowers/`.

## Mobile
- Removed JS `isMobile` (window.innerWidth + resize) from Hero, ScrollArrow, and ProjectModal; converted to Tailwind `md:` responsive classes. Kills the load-time layout flash.
- More work cards stack on phones (image on top, full width), row layout from `sm`.
- Experience: mobile left-rail timeline with dots, tighter spacing; desktop alternating layout unchanged. Date separator is now "to" (no em dash).
- Featured cards are compact by default (header + demo video + what it does); Architecture, Key design decisions, and Stack moved behind a single "Show full breakdown" expander. The dense architecture diagram is horizontally pannable on mobile.
- Enlarged hero recruiter-link tap targets.

## Animation
- All scroll reveals now latch (reveal once, never re-hide), so scrolling up/down no longer replays or stutters them.
- Trigger on viewport entry with a quick 300ms rise (16px) + fade; tight, capped stagger on grids. Tuned to be visible but snappy, not sluggish.
- `useInView` gained a `once` latch. No animation library; CSS transform/transition only.

## Notes
- `prefers-reduced-motion` intentionally not handled this pass.
- Verification: `yarn build` clean, `yarn lint` 0 errors / 0 warnings (down from 6 pre-existing warnings on main).